### PR TITLE
TPM calcs off by 1e3. RPK was not using kilbases.

### DIFF
--- a/calc_fpkm/calc_fpkm.py
+++ b/calc_fpkm/calc_fpkm.py
@@ -187,7 +187,7 @@ class HtseqReader(object):
         Calculate Transcripts per Million normalized counts.
         :return:
         """
-        gene_len = len(set(self.gtf.gene_coords[ensg_id]))
+        gene_len = len(set(self.gtf.gene_coords[ensg_id])) /1000.0
         return float((count/gene_len)/(self.rpk_total/1000000.0))
 
 


### PR DESCRIPTION
gene RPK/(Total RPKs/1e6). Total RPKs were correct but gene RPKs were not by kilobase [reads/(length/1e3)]. 