### PR TITLE
Add nanonstring raw data processing and wrapper

### DIFF
--- a/nanostring/macros.xml
+++ b/nanostring/macros.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<macros>
+
+  <xml name="requirements">
+    <requirements>
+      <requirement type="package" version="@VERSION@">nanostring</requirement>
+    </requirements>
+  </xml>
+
+</macros>
+

--- a/nanostring/process_nanostring.py
+++ b/nanostring/process_nanostring.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+
+## USAGE:
+#   Nanostring output RCC readouts (html format) to raw data matrix
+## NOTES:
+#   TODO: break out tests
+#       checking sample metrics
+#       check for unique sample names in sample sheet
+#
+## ARGUMENTS:
+#   samplesheet: tsv of RCC filename in one col and sample name, 'ANTIBODY_REFERENCE.csv'
+#   rcc files
+#   abfile: antibody file to rename antibody names.
+## RETURN:
+#   rawdata.txt: tab-sep file with table of Antibody x Sample
+#
+import os
+import re
+import argparse
+import pandas
+import xml.etree.ElementTree as ET
+
+VERSION="0.1.0"
+
+def supply_args():
+    """
+    Input arguments
+    """
+    parser = argparse.ArgumentParser(description='Nanostring output RCC readouts (html format) and '
+                                                 'converts to raw data tsv')
+    parser.add_argument('rcc_files', type=str, nargs='+', help='raw RCC files')
+    parser.add_argument('--samplesheet', type=argparse.FileType('r'), help='samplesheet.txt')
+    parser.add_argument('--abfile', nargs='?', type=argparse.FileType('r'),
+                        help='ANTIBODY_REFERENCE.csv')
+    parser.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
+    args = parser.parse_args()
+    return args
+
+def parseRCC(rcc_file):
+    """
+    Take RCC file output df
+    Args:
+        path to RCC
+    Returns:
+        dataframe
+    Examples:
+    """
+    dict_rcc = {}
+    with open(rcc_file, 'r') as xml_handle:
+        complete_xml = "<root>" + str(xml_handle.read()) + "</root>"
+        root = ET.fromstring(complete_xml)
+        for child in root:
+            dict_rcc[child.tag] = child.text
+
+        counts = [line.strip().split(',') for line in dict_rcc['Code_Summary'].strip().split('\n')]
+        header = [line.strip().split(',') for line in dict_rcc['Header'].strip().split('\n')]
+        samp_attrib = [line.strip().split(',') for line in
+                       dict_rcc['Sample_Attributes'].strip().split('\n')]
+        lane_attrib = [line.strip().split(',') for line in
+                       dict_rcc['Lane_Attributes'].strip().split('\n')]
+
+        dfcounts = pandas.DataFrame(counts[1:len(counts)], columns=counts[0])
+        df_samp_attrib = pandas.DataFrame(header, samp_attrib).T
+        df_lane_attrib = pandas.DataFrame(lane_attrib[1:len(lane_attrib)], columns=lane_attrib[0])
+
+    return(dfcounts, df_samp_attrib, df_lane_attrib)
+
+def parse_Ab_ref(abfile):
+    """
+    get antibody shortnames.
+    Args:
+        ab_handle
+    Returns:
+        dict
+    Examples:
+    """
+    ab_name ={}
+    for line in abfile:
+        if not line.lstrip().startswith('#'):
+            items = line.strip().split(",")
+            ab_name[items[1]] = items[0]
+    return(ab_name)
+
+def parse_samplesheet(samplesheet):
+    """
+    get sample names, expecting to get more complex with this.
+    ie. make directory structure to store data, etc
+    Args:
+        samplesheet
+    Returns:
+        dict
+    Examples:
+    """
+    ss_dict = {}
+    with samplesheet:
+        for line in samplesheet:
+            items = line.strip().split("\t")
+            ss_dict[items[0]] = items[1]
+    return(ss_dict)
+
+def main():
+
+    args = supply_args()
+    if len(args.rcc_files) < 12:
+        lrcc = len(args.rcc_files)
+        print("Only ", lrcc, " RCC files specified!\nContinuing with ", lrcc, " files.")
+
+    sampleid = parse_samplesheet(args.samplesheet)
+
+    rcc_counts_dict = {}
+    samp_attrib_dict = {}
+    lane_attrib_dict = {}
+
+    rcc_dir = os.path.dirname(args.rcc_files[1])
+    for file in args.rcc_files:
+        if file.endswith(".RCC"):
+            #get sample number
+            samp_number = re.sub(".RCC", "", file.split("_")[-1])
+            dfrcc, df_samp_attrib, df_lane_attrib = parseRCC(file)
+
+            #rename column name with sample id
+            dfrcc.rename(columns={'Count': sampleid[file]}, inplace=True)
+            rcc_counts_dict[sampleid[file]] = dfrcc
+
+            #df_lane_attrib.rename(columns={df_lane_attrib.columns[1]: sampleid[file]}, inplace=True)
+            df_lane_attrib = df_lane_attrib.append(pandas.Series(['SampleName', sampleid[file]],
+                                            index=df_lane_attrib.columns),ignore_index=True)
+            lane_attrib_dict[df_lane_attrib.columns[1]] = df_lane_attrib
+
+            samp_attrib_dict[sampleid[file]] = df_samp_attrib
+
+            batch_name=re.sub(r'_%s+.RCC' % samp_number, "", file)
+
+    #merge dictionary of dataframes together
+    raw_data = reduce(lambda x, y: pandas.merge(x, y, on=['CodeClass', 'Name', 'Accession']),
+                      rcc_counts_dict.values())
+
+    lane_attrib = reduce(lambda x, y: pandas.merge(x, y, on=['ID']),
+                         lane_attrib_dict.values())
+
+    outputDir = os.path.join(rcc_dir + "OUTPUT")
+
+    try:
+        os.mkdir(outputDir)
+    except OSError as e:
+        if e.errno != 17:
+            raise
+
+
+    # Change long name to something else if necessary
+    if args.abfile:
+        with args.abfile:
+            ab_name = parse_Ab_ref(args.abfile)
+        for name in raw_data["Name"].iteritems():
+            if not re.search("POS|NEG", name[1]):
+                #print(name)
+                raw_data['Name'][name[0]] = ab_name[name[1].strip().split("|")[0]]
+
+    raw_data.to_csv(outputDir + "/rawdata.txt", sep='\t', index=False)
+
+    #test to see if samp_attribs are all the same
+    for v in range(len(samp_attrib_dict.values()) - 1):
+        if samp_attrib_dict.values()[v].equals(samp_attrib_dict.values()[v+1]) != True:
+            print("Samples are not from one batch. Sample Attributes differ")
+            print(samp_attrib_dict.keys()[v])
+        else:
+            print("Samples are from one batch. OK")
+
+    with open(outputDir + "/run_metrics.txt", 'w') as met:
+        met.write(samp_attrib_dict.values()[0].to_csv(sep="\t"))
+        met.write(lane_attrib.to_csv(sep="\t"))
+
+if __name__ == "__main__":
+    main()

--- a/nanostring/process_nanostring.xml
+++ b/nanostring/process_nanostring.xml
@@ -1,0 +1,62 @@
+<tool id='process_nanostring' name='Process and Normalize RCC Files' version='0.0.1'>
+    <description>Process and normalize RCC output from nanostring.</description>
+    
+    <command detect_errors="exit_code"><![CDATA[
+        python $_tool_directory__/process_nanostring.py 
+          "${rcc1}" 
+          "${rcc2}" 
+          "${rcc3}" 
+          "${rcc4}" 
+          "${rcc5}" 
+          "${rcc6}"
+          "${rcc7}"
+          "${rcc8}"
+          "${rcc9}"
+          "${rcc10}"
+          "${rcc11}"
+          "${rcc12}"
+          --samplesheet "${samplesheet}"
+          --abfile "${ab_reference}"
+    ]]></command>
+    
+    <inputs>
+	<param type='data' name='samplesheet' label='Samplesheet' help='samplesheet.txt'/>
+        <param type='data' name='rcc1' label='RCC Files' help='rcc file lane 1'/>
+        <param type='data' name='rcc2' label='RCC Files' help='rcc file lane 2'/>
+        <param type='data' name='rcc3' label='RCC Files' help='rcc file lane 3'/>
+        <param type='data' name='rcc4' label='RCC Files' help='rcc file lane 4'/>
+        <param type='data' name='rcc5' label='RCC Files' help='rcc file lane 5'/>
+        <param type='data' name='rcc6' label='RCC Files' help='rcc file lane 6'/>
+        <param type='data' name='rcc7' label='RCC Files' help='rcc file lane 7'/>
+        <param type='data' name='rcc8' label='RCC Files' help='rcc file lane 8'/>
+        <param type='data' name='rcc9' label='RCC Files' help='rcc file lane 9'/>
+        <param type='data' name='rcc10' label='RCC Files' help='rcc file lane 10'/>
+        <param type='data' name='rcc11' label='RCC Files' help='rcc file lane 11'/>
+        <param type='data' name='rcc12' label='RCC Files' help='rcc file lane 12'/>
+        <param type='csv' name='ab_reference' label='antibody_reference.csv' help='antibody_reference file changes antibody names from the existing ones in RCC files'/>
+    </inputs>
+    <outputs>
+        <data format='tsv' name='rawdata' label='Raw Data $on_string' from_work_dir='rawdata.txt' help=''/>
+        <data format='tsv' name='corrected' label='Corrected Output $on_string' from_work_dir='corrected.tsv' help=''/>
+        <data format='tsv' name='run_metrics' label='Run metrics' from_work_dir='run_metrics.tsv' help=''/>
+    </outputs>
+    <help>
+
+This tool takes multiple RCC files, the output from Nanostring. There is an RCC file per sample in a batch of Nanostring data. 
+
+**Input: 
+ - RCC files 
+ - Nanostring Samplesheet
+ - antibody reference file
+
+**Output:
+ - rawdata.txt: tab-delimited file with the raw data from nanostring
+ - run_metrics.txt: tab-delimited file with run and lane quality metrics
+ - corrected.txt: rawdata numbers corrected for:
+	1. ERCC control, loading contro
+ 	2. Sample level mean for all antibodies per sample
+	3. Immunoglobulin ratio
+
+    </help>
+
+</tool>


### PR DESCRIPTION
First commit to add nanostring processing tool. Processing scripts takes in all 12
RCC files, raw data from nCounter machine, and outputs the rawdata tab separated
file and the run metrics. An antibody_refernce.csv file is an optional input that
changes the antibody names.