### PR TITLE
Compatablize output filenames and dir to work_dir

### DIFF
--- a/nanostring/proc_norm.xml
+++ b/nanostring/proc_norm.xml
@@ -1,4 +1,4 @@
-<tool id='process_nanostring' name='Process and Normalize RCC Files' version='1.0.0'>
+<tool id='proc_norm' name='Process and Normalize RCC Files' version='1.0.0'>
     <description>Process and normalize RCC output from nanostring.</description>    
     <command detect_errors="exit_code"><![CDATA[
         
@@ -23,12 +23,12 @@
         <param type="boolean" name="ctrl" label="Normalize using all samples" help="YES = Normalize using all RCC samples.  NO = Normalize only using cell lines MCF7, HCC1954, BT474, HeyA8, MDA468 control, MDA468control, MDA468+EGF as controls"/>
     </inputs>
     <outputs>
-        <data format="tsv" name="rawdata" label="raw_data $on_string" from_work_dir="rawdata.txt"/>
-        <data format="tsv" name="run_metrics" label="run_metrics $on_string" from_work_dir="run_metrics.txt"/>
-        <data format="tsv" name="ercc" label="1_ERCC_Normalized" from_work_dir="1_ERCC_NORMALIZED.tsv"/>
-        <data format="tsv" name="geomean" label="2_Geomean_Normalized" from_work_dir="2_GEOMEAN_NORMALIZED.tsv"/>
-        <data format="tsv" name="igg" label="3_IGG_Normalized" from_work_dir="3_IGG_NORMALIZED.tsv"/>
-        <data format="tsv" name="log_2" label="4_Log2_Normalized" from_work_dir="4_LOG_2_NORMALIZED.tsv"/>
+        <data format="txt" name="rawdata" label="raw_data $on_string" from_work_dir="rawdata.txt"/>
+        <data format="txt" name="run_metrics" label="run_metrics $on_string" from_work_dir="run_metrics.txt"/>
+        <data format="txt" name="ercc" label="1_ERCC_Normalized" from_work_dir="1_ERCC_NORMALIZED.tsv"/>
+        <data format="txt" name="geomean" label="2_Geomean_Normalized" from_work_dir="2_GEOMEAN_NORMALIZED.tsv"/>
+        <data format="txt" name="igg" label="3_IGG_Normalized" from_work_dir="3_IGG_NORMALIZED.tsv"/>
+        <data format="txt" name="log_2" label="4_Log2_Normalized" from_work_dir="4_LOG_2_NORMALIZED.tsv"/>
     </outputs>
     <help><![CDATA[
 This tool takes multiple RCC files, the output from Nanostring. There is an RCC file per sample in a batch of Nanostring data. 

--- a/nanostring/ruv_mbc.R
+++ b/nanostring/ruv_mbc.R
@@ -67,9 +67,8 @@ pcaplt <- function (mat, title = "PCA Plot", repdf) {
 }
 ## OUTPUT PREP ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-dir.create(paste0(dirname(normalizePath(input_file)), "/OUTPUT"), showWarnings = F)
-output_dir = paste0(dirname(normalizePath(input_file)), "/OUTPUT")
-dir.create(file.path(paste0(dirname(normalizePath(input_file)), "/OUTPUT/ruv_figures")), showWarnings = F)
+output_dir = "."
+dir.create("ruv_figures", showWarnings = F)
 
 ## VALIDATION DATA ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 igg_geosamp = read.csv(validation_file, sep= "\t", row.names = 1)
@@ -123,7 +122,7 @@ ctl_validation$status = ifelse(ctl_validation$new_batch < ctl_validation$mean.mi
                                       ctl_validation$new_batch - ctl_validation$mean.plus.2sd, "PASS"))
 
 
-write.table(ctl_validation, file = paste0(output_dir, "/", "qc_controls.tsv"), 
+write.table(ctl_validation, file = paste0(output_dir, "/", "QC_controls.tsv"), 
             sep="\t", quote = F, row.names = T, col.names = NA)
 
 ## QC LINEAR MODEL ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nanostring/ruv_mbc.xml
+++ b/nanostring/ruv_mbc.xml
@@ -1,23 +1,34 @@
 <tool id='ruv_mbc' name='RUV and Compare with MBC' version='1.0.0'>
     <description>Batch correction using replicates with RUV and compares with a cohort of metastatic breast cancers</description>    
 
+    <requirements>
+      <requirement type="package" version="0.9.7">ruv</requirement>
+      <requirement type="package" version="1.4.3">reshape2</requirement>
+      <requirement type="package" version="3.1.1">ggplot2</requirement>
+    </requirements>
+
     <command detect_errors="exit_code"><![CDATA[
        Rscript $__tool_directory__/ruv_mbc.R
           "${igg_norm}"
           "${validation_data}"
         #if $all_antibody
             include_bad_Ab=TRUE
-        #end if
+        #end if 
+        &&
+        zip -r ruv_figures.zip ruv_figures
     ]]></command>
 
     <inputs>
-        <param name="igg_norm" type="data" label="IgG Normalized TSV" format="tsv,tabular" help="Normalized nanostring data"/>
-        <param name="validation_data" type="data" label="Validation Data" format="tsv,tabular" help="3_IGG_Normalized validation dataset given as input"/>
+        <param name="igg_norm" type="data" label="IgG Normalized TSV" format="txt" help="Normalized nanostring data"/>
+        <param name="validation_data" type="data" label="Validation Data" format="txt,tabular" help="3_IGG_Normalized validation dataset given as input"/>
         <param name="all_antibody" type="boolean" label="Include bad antibodies" checked="false" help="Include antibodies that did not perform very"/>
     </inputs>
 
     <outputs>
-        <data name="MBC_percentiles.tsv" format="tsv" from_work_dir="OUTPUT/MBC_percentiles.tsv" label="${tool.name} on ${on_string}: mbc_percetiles"/>
+        <data name="MBC_percentiles" format="txt" from_work_dir="MBC_percentiles.tsv" label="MBC percentiles: ${tool.name} on ${on_string}"/>
+        <data name="qc_controls" format="txt" from_work_dir="QC_controls.tsv" label="QC Controls: ${tool.name} on ${on_string}"/>
+        <data name="qc_antibody_plot" format="pdf" from_work_dir="QC_antibody_plot.pdf" label="QC Plot antibody comparison: ${tool.name} on ${on_string}"/>
+        <data name="ruv_figures.zip" format="zip" from_work_dir="ruv_figures.zip" label="ruv figures: ${tool.name} on ${on_string}"/>
     </outputs>
 
     <help><![CDATA[

--- a/ruvseq/ruvseq.R
+++ b/ruvseq/ruvseq.R
@@ -1,0 +1,245 @@
+#!/usr/bin/env Rscript
+usage = "
+Runs Davide Risso's version of RUVseq optimized for RNAseq normalized counts
+is just the weights from factor analysis removed from observed variables(genes).
+Not an ideal way to perform factor analysis or perform RUV analysis.
+
+If includeBCCL=T, reccommend count matrix, use filtperc=10, mincnt = 10, normtype=CPM, setk=7.
+If includeBCCL=F, reccommend TPM matrix, use filtperc=10, mincnt = 3, normtype=NONE, setk=1.
+
+Currently wrapped around RUVs,
+Risso et.al. Nature Biotechnology volume 32, (2014)
+
+Inputs:
+1.  mat=matrix 
+2.  includeBCCL = TRUE/FALSE, whether you're data includes the BCCL data 
+with replicates: SkBr3, T47D, HCC1954.
+3.  ctrlregex = regexpr that repeats are based off. ie. \"*UHR*\"
+4.  sampregex = regexpr for samples to filter on. */*16113*/NS500642|NS500681|NB551673
+5.  filtperc: minimum number of samples with counts/tpm/rpkm less that
+filt_cnt filtered out.
+6.  mincnt: minimum number of counts/tpm/rpkm to be filtered out
+7.  normalization prior to RUV. CPM=counts per million, NONE=no normalization
+8.  number of factors to remove
+
+
+Outputs:
+1.  normalizedCounts
+2.  PCA
+3.  Relative log expression plots
+"
+
+suppressPackageStartupMessages(library(argparse))
+suppressPackageStartupMessages(library(RUVSeq))
+suppressPackageStartupMessages(library(ggplot2))
+
+parser <- ArgumentParser()
+parser$add_argument("--mat", help="table/matrix. genes are rows, samples are columns")
+parser$add_argument("--includeBCCL", action="store_true", default=FALSE,
+                    dest="includeBCCL", help="data includes the BCCL")
+parser$add_argument("--ctrlregex", type="character", default="UHR",
+                    dest="ctrlregex", help="regexpr that repeats are based off")
+parser$add_argument("--sampregex", type="character", default="*",
+                    dest="sampregex", help="regexpr for samples to filter on")
+parser$add_argument("--filtperc", type="double", default=10,
+                    dest="filtperc", help = "minimum number of samples with counts/tpm/rpkm less that filt_cnt filtered out")
+parser$add_argument("--mincnt", type="double", default=3,
+                    dest="mincnt", help="minimum number of counts/tpm/rpkm to be filtered out")
+parser$add_argument("--normtype", type="character", default="NONE",
+                    dest="normtype",help="normalization prior to RUV. CPM=counts per million, NONE=no normalization")
+parser$add_argument("--setk", default=1, type="double",
+                    dest="setk",help="number of factors to remove")
+
+args <- parser$parse_args()
+
+mat = args$mat
+includeBCCL = args$includeBCCL
+ctrlregex = args$ctrlregex
+sampregex = args$sampregex
+filtperc= args$filtperc
+mincnt= args$mincnt
+normtype= args$normtype
+setk= args$setk
+
+# Functions
+processRUV <- function(filtmat, includeBCCL=includeBCCL, ctrlregex = ctrlregex, setk){
+  #' Filter by UHR reps by default. Filtmat must include UHR replicates
+  #' 
+  #'  For use in normalize RUV functions
+  #' @param filtmat (matrix): filtered matrix of sample=columns, genes=rows
+  #' @param includeBCCL (logic): TRUE/FALSE
+  #' @param setk (numeric): number of factors to remove. 
+  #' if includeBCCL=T use CPM + setk=7
+  #' if includeBCCL=F use TPM + setk=1
+  #' @return ruvset
+  #' @import RUVSeq
+  #' @export
+  
+  filtmat= as.matrix(round(filtmat, digits=0))
+  
+  #set <- EDASeq::newSeqExpressionSet(as.matrix(filtmat))
+  
+  if (includeBCCL == TRUE){
+    replicate_matx = colnames(filtmat)
+    replicate_matx[grep(ctrlregex, (colnames(filtmat)), value=FALSE)] = "UHR"
+    replicate_matx[grep("*SkBr3*", (colnames(filtmat)), value=FALSE)] = "SkBr3"
+    replicate_matx[grep("*T47D_6*", (colnames(filtmat)), value=FALSE)]="T47D_6"
+    replicate_matx[grep("*HCC1954*", (colnames(filtmat)), value=FALSE)]="HCC1954"
+  } else {
+    print("no BCCL")
+    replicate_matx = colnames(filtmat)
+    replicate_matx[grep(ctrlregex, (colnames(filtmat)), value=FALSE)] = "UHR"
+  }
+  scIdx = RUVSeq::makeGroups(replicate_matx)
+  dim(scIdx)
+  ruvs_set <- RUVSeq::RUVs(filtmat, cIdx=rownames(filtmat), k=setk, scIdx=scIdx)
+  return(ruvs_set)
+  
+}
+
+normalizeRUV <- function(exp_matx=exp_matx, 
+                         includeBCCL=includeBCCL, 
+                         sampregex=sampregex,
+                         ctrlregex=ctrlregex,
+                         filtperc=filtperc, 
+                         mincnt=mincnt, 
+                         normtype=normtype, 
+                         setk) {
+  #' normalize RUV
+  #' 
+  #' Takes a matrix and filters by counts greater than 10 in filtperc \% of SMMART samples
+  #' @param exp_matx: matrix of expression, rownames=genes
+  #' @param includeBCCL: TRUE OR FALSE
+  #' @param sampregex: regular expression of samples to use for filtering
+  #' @param ctrlregex: samples to filter the counts on
+  #' @param filtperc (int): 10\% of SMMART samples will have counts greater than mincnt
+  #' @param mincnt (int): TPM use 3, counts to CPM use 10
+  #' @param normtype (string): "NONE", "CPM"
+  #' @param setk (numeric): number of factors to remove. 
+  #' if includeBCCL=T use CPM, setk=7, filtperc=10, mincnt = 10, 
+  #' if includeBCCL=F use TPM, setk=1, filtperc=10, mincnt = 3, 
+  #' @return list of matrices
+  #' 
+  #' @export
+  #smmart samples differentiated by sequencer name
+  samples_to_filter_on = colnames(exp_matx[,grepl(sampregex, colnames(exp_matx))])
+  filtprop = as.numeric(filtperc)/100
+  
+  cnts = exp_matx
+  
+  if (normtype =="NONE"){
+    #get SMMART only
+    smmartcnts = cnts[,samples_to_filter_on]
+    #FILTER by samples in smmart only
+    perc_smmart = floor(filtprop*(ncol(smmartcnts)))
+    gene_smmart = rownames(smmartcnts[apply(data.frame(smmartcnts), 1, 
+                                            function(x) length(x[x>mincnt])>=perc_smmart),])
+    filtmat = cnts[gene_smmart,]
+    #ruv
+    ruvs = processRUV(filtmat = filtmat, includeBCCL=includeBCCL, ctrlregex = ctrlregex, setk=setk)
+    
+  }
+  
+  if (normtype =="CPM"){
+    #cpm 
+    cpm = apply(cnts,2, function(x) (x/sum(x))*1000000)
+    #get SMMART only
+    smmartcpm = cpm[,samples_to_filter_on]
+    #FILTER
+    perc_smmart = floor(filtprop*(ncol(smmartcpm)))
+    genelistcpm = rownames(smmartcpm[apply(data.frame(smmartcpm), 1, 
+                                           function(x) length(x[x>mincnt])>=perc_smmart),])
+    filtcpm = cpm[genelistcpm,]
+    #ruv cpm
+    ruvs = processRUV(filtmat = filtcpm, includeBCCL=includeBCCL, ctrlregex = ctrlregex, setk=setk)
+  }
+  return(ruvs)
+}
+
+# Plotting Functions
+
+pcaplt<- function(mat, title="PCA Plot"){
+  #' PCA plot function
+  #' @param mat: dataframe, datatable. First column is gene names, rows are genes, columns are samples.
+  #' @param title (string): Title of PCA plot.
+  #' @return pcaplot
+  #' @export
+  lg=log(mat[,-1]+1)
+  #lg=mat
+  var=lg[apply(lg, 1, var, na.rm=TRUE) != 0,]
+  cc.var=var[complete.cases(var),]
+  
+  pca_prcomp = prcomp(t(var), center = T, scale = F)
+  
+  PC1_and_PC2 = data.frame(PC1=pca_prcomp$x[,1], PC2= pca_prcomp$x[,2], type = rownames(pca_prcomp$x))
+  PC1_and_PC2$col = ifelse(grepl(ctrlregex, PC1_and_PC2$type), "replicate", "sample")
+  
+  perc=(pca_prcomp$sdev^2)/sum(pca_prcomp$sdev^2) *100
+  labs <- sapply(seq_along(perc), function(i) {paste("PC ", i, " (", round(perc[i], 2), "%)", sep = "")})
+  
+  
+  p=ggplot(PC1_and_PC2,aes(PC1, PC2)) + 
+    geom_point(aes(colour=col), size=4) +
+    geom_text(aes(label=type, colour=col), vjust=-1) +
+    scale_color_manual(values = c("sample" = "black", "replicate" = "red")) +
+    labs(title=title, x=labs[1], y=labs[2]) +
+    theme(panel.background = element_rect(fill = "white"),
+          panel.grid.major=element_line(colour="gray"),
+          plot.title = element_text(hjust = 0.5),
+          legend.text=element_text(size=4),
+          legend.position="right")
+  return(p)
+}
+
+
+bprle <- function (mat, title="RLE", ...){
+  #' Prettier relative log expression (RLE) boxplots
+  #' 
+  #' @param mat: make it matrix.
+  #' @param title (string): title of the box plot.
+  #' @return boxplot
+  #' @export
+  par(mar=c(20,2,1,1))
+  #x=counts(set)
+  y <- log2(mat + 1)
+  median <- apply(y, 1, median)
+  rle <- apply(y, 2, function(x) x - median)
+  colors=ifelse(grepl(ctrlregex, colnames(mat)), "red", "gray")
+  #boxplot(rle, ..., outline=FALSE, las=2, col=colors[pData(set)[["batch"]]], main=title, cex.axis=0.6, legend="bottom")
+  boxplot(rle, ..., las=2, main=title, outline=FALSE, col=colors)
+  abline(h = 0, lty = 2)
+}
+
+
+## MAIN
+
+exp_matx = read.csv(mat, sep="\t", row.names = 1)
+
+
+
+ruv_seqobj = normalizeRUV(exp_matx = exp_matx, 
+                          includeBCCL = includeBCCL,
+                          sampregex = sampregex,
+                          ctrlregex = ctrlregex,
+                          filtperc=filtperc, 
+                          mincnt=mincnt, 
+                          normtype=normtype, 
+                          setk = setk)
+
+norm_ruv =ruv_seqobj$normalizedCounts
+
+pre_pca = pcaplt(exp_matx, "PCA of Input Data")
+post_pca = pcaplt(norm_ruv, "PCA of RUV Processed Data")
+
+
+write.table(norm_ruv, file=paste0("normRUV.txt"), sep="\t", col.names = NA, row.names = T, quote = F)
+pdf("normalization_plots.pdf", pointsize=14)
+pre_pca
+post_pca
+bprle(exp_matx, "Relative Log Exp of Input Data")
+bprle(norm_ruv, "Relative Log Exp Processed Data")
+
+dev.off()
+
+
+

--- a/ruvseq/ruvseq.xml
+++ b/ruvseq/ruvseq.xml
@@ -1,0 +1,73 @@
+<tool id='ruvseq' name='RUVSeq' version='1.0.0'>
+    <description>RUV: Removal of Unwanted Variation</description>    
+
+    <requirements>
+      <requirement type="package" version="2.0.1">argparse</requirement>
+      <requirement type="package" version="3.1.1">ggplot2</requirement>
+      <requirement type="package" version="1.16.1">RUVSeq</requirement>
+    </requirements>
+    
+    <command detect_errors="exit_code"><![CDATA[        
+        Rscript $__tool_directory__/ruvseq.R 
+          --mat "${input}"
+        #if $includeBCCL
+          --includeBCCL
+        #end if
+          --ctrlregex '$ctrlregex'
+          --sampregex '$sampregex'
+          --filtperc "${filtperc}"
+          --mincnt "${mincnt}"
+          --normtype "${normtype}"
+          --setk "${setk}"
+    ]]></command>
+    
+    <inputs>
+        <param name="input" format="tabular" type="data" label="input table" help="data matrix"/>
+        <param name="includeBCCL" type="select" value="FALSE" multiple="false" label="includeBCCL: boolean indicating whether data includes breast cell lines with replicates." help="">
+            <option value="FALSE">FALSE</option>
+            <option value="TRUE">TRUE</option>
+        </param>
+        <param name="ctrlregex" type="text" value="*UHR*" label="Regex of replicates/controls: Pattern match sample names indicating replicates or controls." help="Percent of samples (Percent filter) matching regex pattern (Regex for filtering) with counts greater than minimum counts (Minimum counts)."/>
+        <param name="sampregex" type="text" value="*" label="Regex for filtering: " help=""/>
+        <param name="filtperc" type="integer" value="10" label="Percent filter" help=""/>
+        <param name="mincnt" type="integer" value="3" label="Minimum count" help=""/>
+        <param name="normtype" type="select" multiple="false" label="Normalization type" help="If counts are given use CPM. If TPM are give then use NONE">
+          <option value="NONE">NONE</option>
+          <option value="CPM">CPM</option>
+        </param>
+        <param name="setk" type="integer" value="1" label="k" help="Number of factors to remove during factor analysis."/> 
+    </inputs>
+
+    <outputs>
+        <data name="normRUV" format="txt" from_work_dir="normRUV.txt" label="norm ${tool.name} on ${on_string}"/>
+        <data name="ruv_plots" format="pdf" from_work_dir="normalization_plots.pdf" label="ruv_plots ${tool.name} on ${on_string}"/>
+    </outputs>
+
+    <help><![CDATA[
+
+Runs Davide Risso's version of RUVseq optimized for RNAseq normalized counts
+is just the weights from factor analysis removed from observed variables(genes).
+Not an ideal way to perform factor analysis or perform RUV analysis.
+
+If includeBCCL=T, reccommend count matrix, use filtperc=10, mincnt = 10, normtype=CPM, setk=7.
+If includeBCCL=F, reccommend TPM matrix, use filtperc=10, mincnt = 3, normtype=NONE, setk=1.
+
+Currently wrapped around RUVs,
+Risso et.al. Nature Biotechnology volume 32, (2014)
+
+Inputs:
+1.  mat=matrix 
+2.  includeBCCL = TRUE/FALSE, whether you're data includes the BCCL data 
+with replicates: SkBr3, T47D, HCC1954.
+3.  ctrlregex = regexpr that repeats are based off. ie. \"*UHR*\"
+4.  sampregex = regexpr for samples to filter on. */*16113*/NS500642|NS500681|NB551673
+5.  filtperc: minimum number of samples with counts/tpm/rpkm less that
+filt_cnt filtered out.
+6.  mincnt: minimum number of counts/tpm/rpkm to be filtered out
+7.  normalization prior to RUV. CPM=counts per million, NONE=no normalization
+8.  number of factors to remove
+
+
+    ]]></help>
+
+</tool>


### PR DESCRIPTION
Output from ruv_mbc.R was outputting files into a new OUTPUT directory. Easier for galaxy to get it from the working directory and easier to grap the zipped directory of ruv_figures. Updated xml to map accordingly

Changed proc_norm.xml was still being called process_nanostring.xml. Changed to proc_norm to match with corresponding wrapper. tsv files don't exist in old exaclinical version so updated to txt.