### PR TITLE
CGD-1984 - create page that displays transcript effects comparison

### DIFF
--- a/cgd_tx_eff/cgd_tx_eff.xml
+++ b/cgd_tx_eff/cgd_tx_eff.xml
@@ -1,4 +1,4 @@
-<tool id="cgd_tx_eff" name="CGD Transcript Effects" version="0.2.3" >
+<tool id="cgd_tx_eff" name="CGD Transcript Effects" version="0.2.4" >
   <description>
   	Apply transcript-effects annotations from Annovar and HGVS to a VCF.
   	Note: This configuration doesn't work yet. 

--- a/cgd_tx_eff/cgd_tx_eff.xml
+++ b/cgd_tx_eff/cgd_tx_eff.xml
@@ -1,4 +1,4 @@
-<tool id="cgd_tx_eff" name="CGD Transcript Effects" version="0.2.2" >
+<tool id="cgd_tx_eff" name="CGD Transcript Effects" version="0.2.3" >
   <description>
   	Apply transcript-effects annotations from Annovar and HGVS to a VCF.
   	Note: This configuration doesn't work yet. 

--- a/cgd_tx_eff/cgd_tx_eff.xml
+++ b/cgd_tx_eff/cgd_tx_eff.xml
@@ -1,4 +1,4 @@
-<tool id="cgd_tx_eff" name="CGD Transcript Effects" version="0.2.4" >
+<tool id="cgd_tx_eff" name="CGD Transcript Effects" version="0.2.5" >
   <description>
   	Apply transcript-effects annotations from Annovar and HGVS to a VCF.
   	Note: This configuration doesn't work yet. 

--- a/cgd_tx_eff/cgd_tx_eff.xml
+++ b/cgd_tx_eff/cgd_tx_eff.xml
@@ -1,4 +1,4 @@
-<tool id="cgd_tx_eff" name="CGD Transcript Effects" version="0.2.5" >
+<tool id="cgd_tx_eff" name="CGD Transcript Effects" version="0.2.6" >
   <description>
   	Apply transcript-effects annotations from Annovar and HGVS to a VCF.
   	Note: This configuration doesn't work yet. 
@@ -47,6 +47,7 @@
   <outputs>
     <data format="vcf" name="out_vcf" label="${tool.name} on ${on_string}: VCF" />
     <data format="tsv" name="invalid_variants" label="Variants with invalid input format" from_work_dir="annovar.invalid_input"/>
+    <data format="txt" name="log_file" label="Log file" from_work_dir="cgd_tx_eff.log"/>
   </outputs>
 
   <tests>

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -307,13 +307,16 @@ class AnnovarParser(object):
             reader = csv.reader(annovar_file, delimiter = delimiter)
             for row in reader:
                 if annovar_file_type == AnnovarFileType.ExonicVariantFunction:
-                    assert len(row) == 18, f"Exonic variant function file must have 18 columns. Found {len(row)}. Make sure you run the annotate_variation.pl script with the '--otherinfo' parameter to include other information from the original VCF"
                     assert row[0].startswith('line')
+                    if len(row) != 18:
+                        logger.info(f"Exonic variant function file is expected have 18 columns. Found {len(row)}. Make sure you run the annotate_variation.pl script with the '--otherinfo' parameter to include other information from the original VCF")
+                    
 
                     # Parse a row in an exonic_variant_function file
                     annovar_recs.extend(self._parse_exonic_variant_function_row(row))
                 elif annovar_file_type == AnnovarFileType.VariantFunction:
-                    assert len(row) == 17, f"Variant function file must have 17 columns. Found {len(row)}. Make sure you run the annotate_variation.pl with the '--otherinfo' parameter to include other information from the original VCF"
+                    if len(row) != 17:
+                        logger.info(f"Variant function file file is expected to have 17 columns. Found {len(row)}. Make sure you run the annotate_variation.pl with the '--otherinfo' parameter to include other information from the original VCF")
                     
                     # Parse a row in a variant_function file
                     annovar_recs.extend(self._parse_variant_function_row(row))

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -11,6 +11,7 @@ import logging
 from collections import defaultdict
 import re
 import os
+from hgvs.location import BaseOffsetPosition
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -121,6 +122,11 @@ class AnnovarParser(object):
             # it isn't possible to recover. 
             hgvs_basep = self.hgvs_parser.parse(full_c).posedit.pos.start
             
+            # Sometimes basepair position is an integer, but it can also be an offset (eg c.371-3C>T)
+            if hgvs_basep and type(hgvs_basep) is BaseOffsetPosition:
+                logger.debug(f"Converting base pair position to string because it is an offset: {full_c}")
+                hgvs_basep = str(hgvs_basep)
+            
             # p. single letter amino acid; not always present
             if len(transcript_parts) == 5:
                 hgvs_p = transcript_parts[4]                 
@@ -178,6 +184,12 @@ class AnnovarParser(object):
             try:
                 full_c = ':'.join([refseq_transcript, hgvs_c_dot])
                 hgvs_basep = self.hgvs_parser.parse(full_c).posedit.pos.start
+                
+                # Sometimes basepair position is an integer, but it can also be an offset (eg c.371-3C>T)
+                if hgvs_basep and type(hgvs_basep) is BaseOffsetPosition:
+                    logger.debug(f"Converting base pair position to string because it is an offset: {full_c}")
+                    hgvs_basep = str(hgvs_basep)
+
             except hgvs.exceptions.HGVSParseError:
                 hgvs_basep = None
                 c_dot_alt = re.search(r"c\..*\>([\w]+)", hgvs_c_dot)            

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -13,17 +13,6 @@ import re
 import os
 from hgvs.location import BaseOffsetPosition
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-stream_handler = logging.StreamHandler()
-logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-stream_format = logging.Formatter(logging_format)
-stream_handler.setFormatter(stream_format)
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
-
 class AnnovarFileType(Enum):
     '''
     Annovar file types supported by this parser
@@ -104,7 +93,7 @@ class AnnovarParser(object):
         raw_exon = transcript_parts[2]
 
         if raw_exon == 'wholegene':
-            logger.debug(f'This transcript\'s raw_exon value is \'wholegene\' and is of no use: {transcript_parts}')
+            logging.debug(f'This transcript\'s raw_exon value is \'wholegene\' and is of no use: {transcript_parts}')
             amino_acid_position = None 
             hgvs_basep = None
             exon = None
@@ -124,7 +113,7 @@ class AnnovarParser(object):
             
             # Sometimes basepair position is an integer, but it can also be an offset (eg c.371-3C>T)
             if hgvs_basep and type(hgvs_basep) is BaseOffsetPosition:
-                logger.debug(f"Converting base pair position to string because it is an offset: {full_c}")
+                logging.debug(f"Converting base pair position to string because it is an offset: {full_c}")
                 hgvs_basep = str(hgvs_basep)
             
             # p. single letter amino acid; not always present
@@ -136,11 +125,11 @@ class AnnovarParser(object):
                     hgvs_three = 'p.' + str(parsed_p_dot.posedit)
                     amino_acid_position = parsed_p_dot.posedit.pos.start.pos                
                 except hgvs.exceptions.HGVSParseError as e:
-                    logger.warning(f"Unable to parse {full_p}: {e}")
+                    logging.warning(f"Unable to parse {full_p}: {e}")
                     hgvs_three = None
                     amino_acid_position = None                
             else:
-                logger.debug(f"This transcript is missing the p. but that's ok, HGVS will fill it in: {transcript_parts}")
+                logging.debug(f"This transcript is missing the p. but that's ok, HGVS will fill it in: {transcript_parts}")
                 amino_acid_position = None
                 hgvs_p = None
                 hgvs_three = None
@@ -160,7 +149,7 @@ class AnnovarParser(object):
         if tuple_type == 1:
             # Don't use the intergenic transcripts that are labeled with "dist=nnn"
             if delimited_transcript.find('(dist=') > 0:
-                logger.debug(f'Found intergenic transcript that will be thrown out: {delimited_transcript}')
+                logging.debug(f'Found intergenic transcript that will be thrown out: {delimited_transcript}')
                 refseq_transcript = None
             else:
                 refseq_transcript = delimited_transcript
@@ -187,7 +176,7 @@ class AnnovarParser(object):
                 
                 # Sometimes basepair position is an integer, but it can also be an offset (eg c.371-3C>T)
                 if hgvs_basep and type(hgvs_basep) is BaseOffsetPosition:
-                    logger.debug(f"Converting base pair position to string because it is an offset: {full_c}")
+                    logging.debug(f"Converting base pair position to string because it is an offset: {full_c}")
                     hgvs_basep = str(hgvs_basep)
 
             except hgvs.exceptions.HGVSParseError:
@@ -195,7 +184,7 @@ class AnnovarParser(object):
                 c_dot_alt = re.search(r"c\..*\>([\w]+)", hgvs_c_dot)            
                 if c_dot_alt and len(c_dot_alt.group(1)) > 1:
                     # This doesn't matter because we use the c. from HGVS/UTA not this one from Annovar
-                    logger.debug(f"HGVS parser failed to determine c. because the parser expects the c. alt to be just one base, but is {len(c_dot_alt.group(1))}: {hgvs_c_dot}")
+                    logging.debug(f"HGVS parser failed to determine c. because the parser expects the c. alt to be just one base, but is {len(c_dot_alt.group(1))}: {hgvs_c_dot}")
         else:
             hgvs_basep = None
 
@@ -214,11 +203,11 @@ class AnnovarParser(object):
         ref = annovar_row[11]
         alt = annovar_row[12]
         
-        logger.debug(f"Parsing variant {chrom}-{pos}-{ref}-{alt}")
+        logging.debug(f"Parsing variant {chrom}-{pos}-{ref}-{alt}")
         
         if annovar_row[2] == 'UNKNOWN':
             # Don't bother with unknown types
-            logger.debug("Variant is UNKNOWN type.")
+            logging.debug("Variant is UNKNOWN type.")
             return []
 
         # The exonic_variant_function file provides variant effect ("VFX in the old code)
@@ -226,7 +215,7 @@ class AnnovarParser(object):
         variant_type = None
         
         transcript_tuples = annovar_row[2].rstrip(',').split(',')
-        logger.debug(f"row has {len(transcript_tuples)} transcript tuples")
+        logging.debug(f"row has {len(transcript_tuples)} transcript tuples")
 
         for transcript_tuple in transcript_tuples:
             avf = AnnovarVariantFunction(chrom, pos, ref, alt)
@@ -243,7 +232,7 @@ class AnnovarParser(object):
             avf.hgvs_p_dot_three,         \
             avf.refseq_transcript = self._unpack_evf_transcript_tuple(transcript_tuple)
 
-            logger.debug(f"Parsed exonic_variant_function with transcript: {avf}")
+            logging.debug(f"Parsed exonic_variant_function with transcript: {avf}")
             annovar_recs.append(avf)
 
         return annovar_recs
@@ -262,7 +251,7 @@ class AnnovarParser(object):
         ref = annovar_row[10]
         alt = annovar_row[11]
         
-        logger.debug(f"Parsing variant {chrom}-{pos}-{ref}-{alt}")
+        logging.debug(f"Parsing variant {chrom}-{pos}-{ref}-{alt}")
         
         # Handle special cases of splicing variants
         if annovar_row[0] == 'splicing' or annovar_row[0] == 'ncRNA_splicing':            
@@ -277,7 +266,7 @@ class AnnovarParser(object):
         if(len(transcript_tuples) == 0):
             raise Exception(f"Variant does not have any transcript tuples: {chrom}-{pos}-{ref}-{alt}")
             
-        logger.debug(f"row has {len(transcript_tuples)} transcript tuples")
+        logging.debug(f"row has {len(transcript_tuples)} transcript tuples")
         
         for transcript_tuple in transcript_tuples:
             avf = AnnovarVariantFunction(chrom, pos, ref, alt)
@@ -294,10 +283,10 @@ class AnnovarParser(object):
             avf.refseq_transcript = self._unpack_vf_transcript_tuple(transcript_tuple)
             
             if avf.refseq_transcript == None:
-                logger.debug("Ignoring transcript. Probably because it was intergenic and didn't have any useful tfx.")
+                logging.debug("Ignoring transcript. Probably because it was intergenic and didn't have any useful tfx.")
                 continue
 
-            logger.debug(f"Parsed variant_function record with transcript: {avf}")
+            logging.debug(f"Parsed variant_function record with transcript: {avf}")
             annovar_recs.append(avf)
         
         return annovar_recs
@@ -312,7 +301,7 @@ class AnnovarParser(object):
 
         if (os.path.getsize(file_name) == 0):
             # Sometimes none of the variants are exonic so the exonic file is empty. 
-            logger.info(f"Annovar file {annovar_file_type} is empty.")
+            logging.info(f"Annovar file {annovar_file_type} is empty.")
             return annovar_recs
             
         with open(file_name, 'r') as annovar_file:
@@ -321,14 +310,14 @@ class AnnovarParser(object):
                 if annovar_file_type == AnnovarFileType.ExonicVariantFunction:
                     assert row[0].startswith('line')
                     if len(row) != 18:
-                        logger.info(f"Exonic variant function file is expected have 18 columns. Found {len(row)}. Make sure you run the annotate_variation.pl script with the '--otherinfo' parameter to include other information from the original VCF")
+                        logging.info(f"Exonic variant function file is expected have 18 columns. Found {len(row)}. Make sure you run the annotate_variation.pl script with the '--otherinfo' parameter to include other information from the original VCF")
                     
 
                     # Parse a row in an exonic_variant_function file
                     annovar_recs.extend(self._parse_exonic_variant_function_row(row))
                 elif annovar_file_type == AnnovarFileType.VariantFunction:
                     if len(row) != 17:
-                        logger.info(f"Variant function file file is expected to have 17 columns. Found {len(row)}. Make sure you run the annotate_variation.pl with the '--otherinfo' parameter to include other information from the original VCF")
+                        logging.info(f"Variant function file file is expected to have 17 columns. Found {len(row)}. Make sure you run the annotate_variation.pl with the '--otherinfo' parameter to include other information from the original VCF")
                     
                     # Parse a row in a variant_function file
                     annovar_recs.extend(self._parse_variant_function_row(row))
@@ -348,7 +337,7 @@ class AnnovarParser(object):
         key_maker = lambda x: "-".join([x.chromosome, str(x.position), x.reference, x.alt, x.refseq_transcript, (x.splicing or '')])
         for annovar_rec in annovar_records:
             if annovar_rec.chromosome == None or annovar_rec.position == None or annovar_rec.reference == None or annovar_rec.alt == None or annovar_rec.refseq_transcript == None:
-                logger.error(f"There is going to be a problem with {annovar_rec}")
+                logging.error(f"There is going to be a problem with {annovar_rec}")
                 exit
             annovar_dict[key_maker(annovar_rec)].append(annovar_rec)
 
@@ -370,7 +359,7 @@ class AnnovarParser(object):
                 raise Exception(f"This transcript has more than 2 instances, which is not supported; see code comment. rec={left_rec}")
             elif len(matching_genotypes) == 2:
                 right_rec = matching_genotypes[1]
-                logger.debug(f"Merging left={left_rec} and right={right_rec}")
+                logging.debug(f"Merging left={left_rec} and right={right_rec}")
                 self._merge(left_rec, right_rec)
             
             annovar_records.append(left_rec)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -10,6 +10,7 @@ import hgvs.parser
 import logging
 from collections import defaultdict
 import re
+import os
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -89,37 +90,7 @@ class AnnovarParser(object):
     Parses Annovar output
     ''' 
     def __init__(self):
-        self.hgvs_parser = hgvs.parser.Parser()
-    
-    def _get_file_type(self, file_name:str):
-        '''
-        Return the Annovar output type as determined by its contents
-        '''
-        
-        # These are the allowable keywords for variant functions (https://annovar.openbioinformatics.org/en/latest/user-guide/gene/) 
-        variant_functions = ['UTR3', 'UTR5', 'downstream', 'exonic', 'intronic', 'ncRNA_exonic', 'ncRNA_intronic', 'ncRNA_splicing', 'splicing', 'upstream']
-        
-        first_line = self.__read_first_line(file_name)
-        
-        if first_line[0].startswith('line'):
-            # Field zero is 'lineN' and 'chrX' is in the third field for *.exonic_variant_function files
-            return AnnovarFileType.ExonicVariantFunction
-        elif first_line[0] in variant_functions:            
-            return AnnovarFileType.VariantFunction
-        else:
-            raise Exception(f"Unrecognized Annovar file type: {file_name}")
-        
-    def __read_first_line(self, filename: str, delimiter = '\t'):
-        '''
-        Read the first line of a delimited file. The function is used to determine the file type.
-        '''
-        with open(filename, 'r') as annovar_file:
-            reader = csv.reader(annovar_file, delimiter = delimiter)
-            for row in reader:
-                return row
-        
-        raise Exception(f"File is empty: {filename}")
-            
+        self.hgvs_parser = hgvs.parser.Parser()            
 
     def _unpack_evf_transcript_tuple(self, delimited_transcript: str):
         '''
@@ -320,15 +291,18 @@ class AnnovarParser(object):
         return annovar_recs
 
 
-    def parse_file(self, file_name:str, delimiter = '\t'):
+    def parse_file(self, annovar_file_type: AnnovarFileType, file_name:str, delimiter = '\t'):
         '''
         Read an Annovar file and return a list of variants 
         '''
 
-        annovar_file_type = self._get_file_type(file_name)
-
         annovar_recs = []
 
+        if (os.path.getsize(file_name) == 0):
+            # Sometimes none of the variants are exonic so the exonic file is empty. 
+            logger.info(f"Annovar file {annovar_file_type} is empty.")
+            return annovar_recs
+            
         with open(file_name, 'r') as annovar_file:
             reader = csv.reader(annovar_file, delimiter = delimiter)
             for row in reader:

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/avinput2vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/avinput2vcf.py
@@ -5,19 +5,9 @@ Convert an Annovar *.avinput file to VCF
 @author: pleyte
 '''
 import argparse
-import logging
+import logging.config
 import csv
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-stream_handler = logging.StreamHandler()
-logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-stream_format = logging.Formatter(logging_format)
-stream_handler.setFormatter(stream_format)
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 
 class Variant(object):
     def __init__(self):        
@@ -111,15 +101,17 @@ def _main():
     '''
     main function
     '''
+    logging.config.dictConfig(TfxLogConfig().utility_config)
+
     args = _parse_args()
     
     variants = _read_avinput_variants(args.in_file.name)
     
-    logger.info(f"Read {len(variants)} variants from {args.in_file.name}")
+    logging.info(f"Read {len(variants)} variants from {args.in_file.name}")
     
     _write_vcf(args.out_file.name, variants)
     
-    logger.info(f"Wrote VCF {args.out_file.name}")
+    logging.info(f"Wrote VCF {args.out_file.name}")
     
 if __name__ == '__main__':
     _main()

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/csv2avinput.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/csv2avinput.py
@@ -6,22 +6,11 @@ Created on Jul 11, 2022
 @author: pleyte
 '''
 import argparse
-import logging
+import logging.config
 import csv
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 
 VERSION = '0.0.1'
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-stream_handler = logging.StreamHandler()
-logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-stream_format = logging.Formatter(logging_format)
-stream_handler.setFormatter(stream_format)
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
-
 
 def _parse_args():
     '''
@@ -47,6 +36,8 @@ def _main():
     '''
     main function
     '''
+    logging.config.dictConfig(TfxLogConfig().utility_config)
+    
     args = _parse_args()
 
     with open(args.csv.name) as csv_file, open(args.out_file.name, "w") as tsv_out_file:
@@ -63,7 +54,7 @@ def _main():
         for row in csv_reader:
             key = key_maker(row)
             if key in keys:
-                logger.debug(f"Skipping duplicate variant {key}")
+                logging.debug(f"Skipping duplicate variant {key}")
                 duplicates = duplicates + 1
             else:
                 tsv_writer.writerow([row['chromosome'], row['position_start'], row['position_end'], row['reference_base'], row['variant_base'],
@@ -74,10 +65,10 @@ def _main():
    
             total = total + 1
             
-    logger.info(f"duplicate count={duplicates}")
-    logger.info(f"unique count={rowId}")
-    logger.info(f"total={total}")
-    logger.info(f"Wrote {args.out_file.name}")
+    logging.info(f"duplicate count={duplicates}")
+    logging.info(f"unique count={rowId}")
+    logging.info(f"total={total}")
+    logging.info(f"Wrote {args.out_file.name}")
             
 if __name__ == '__main__':
     _main()

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annovar.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annovar.py
@@ -16,7 +16,7 @@ from edu.ohsu.compbio.annovar import annovar_parser
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 from edu.ohsu.compbio.annovar.annovar_parser import AnnovarFileType
 
-VERSION = '0.2.3'
+VERSION = '0.2.4'
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annovar.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annovar.py
@@ -16,7 +16,7 @@ from edu.ohsu.compbio.annovar import annovar_parser
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 from edu.ohsu.compbio.annovar.annovar_parser import AnnovarFileType
 
-VERSION = '0.0.1'
+VERSION = '0.2.3'
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annovar.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annovar.py
@@ -14,6 +14,7 @@ import argparse
 import logging
 from edu.ohsu.compbio.annovar import annovar_parser
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
+from edu.ohsu.compbio.annovar.annovar_parser import AnnovarFileType
 
 VERSION = '0.0.1'
 
@@ -65,12 +66,17 @@ def get_annovar_records(annovar_variant_function_filename: str, annovar_exonic_v
         
     annovar_records = []
     annovarParser = annovar_parser.AnnovarParser()
-    
-    for file_name in [annovar_variant_function_filename, annovar_exonic_variant_function_filename]:
-        file_transcripts = annovarParser.parse_file(file_name)
-        logger.debug(f'Read {len(file_transcripts)} transcripts from {file_name}')    
-        annovar_records.extend(file_transcripts)
 
+    # Parse the variant_function file
+    file_transcripts = annovarParser.parse_file(AnnovarFileType.VariantFunction, annovar_variant_function_filename)
+    logger.debug(f'Read {len(file_transcripts)} transcripts from {annovar_variant_function_filename}')    
+    annovar_records.extend(file_transcripts)
+    
+    # Parse the exonic_variant_function file
+    file_transcripts = annovarParser.parse_file(AnnovarFileType.ExonicVariantFunction, annovar_exonic_variant_function_filename)
+    logger.debug(f'Read {len(file_transcripts)} transcripts from {annovar_exonic_variant_function_filename}')
+    annovar_records.extend(file_transcripts)
+    
     disinct_variant_count = len({f'{x.chromosome}-{x.position}-{x.reference}-{x.alt}' for x in annovar_records})
     logger.debug(f'Read {disinct_variant_count} distinct variants and {len(annovar_records)} transcripts from annovar files')
 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annovar.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annovar.py
@@ -11,24 +11,13 @@ Created on Apr 14, 2022
 '''
 
 import argparse
-import logging
+import logging.config
 from edu.ohsu.compbio.annovar import annovar_parser
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 from edu.ohsu.compbio.annovar.annovar_parser import AnnovarFileType
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 
 VERSION = '0.2.4'
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-stream_handler = logging.StreamHandler()
-logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-stream_format = logging.Formatter(logging_format)
-stream_handler.setFormatter(stream_format)
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
-
 
 def _parse_args():
     '''
@@ -62,29 +51,29 @@ def get_annovar_records(annovar_variant_function_filename: str, annovar_exonic_v
     Parse Annovar records from the list files 
     '''
     if annovar_variant_function_filename == None or annovar_exonic_variant_function_filename is None:
-        logger.warning(f"Annovar input file(s) not provided and this may cause errors during processing: vf={annovar_variant_function_filename}, evf={annovar_exonic_variant_function_filename}")
+        logging.warning(f"Annovar input file(s) not provided and this may cause errors during processing: vf={annovar_variant_function_filename}, evf={annovar_exonic_variant_function_filename}")
         
     annovar_records = []
     annovarParser = annovar_parser.AnnovarParser()
 
     # Parse the variant_function file
     file_transcripts = annovarParser.parse_file(AnnovarFileType.VariantFunction, annovar_variant_function_filename)
-    logger.debug(f'Read {len(file_transcripts)} transcripts from {annovar_variant_function_filename}')    
+    logging.debug(f'Read {len(file_transcripts)} transcripts from {annovar_variant_function_filename}')    
     annovar_records.extend(file_transcripts)
     
     # Parse the exonic_variant_function file
     file_transcripts = annovarParser.parse_file(AnnovarFileType.ExonicVariantFunction, annovar_exonic_variant_function_filename)
-    logger.debug(f'Read {len(file_transcripts)} transcripts from {annovar_exonic_variant_function_filename}')
+    logging.debug(f'Read {len(file_transcripts)} transcripts from {annovar_exonic_variant_function_filename}')
     annovar_records.extend(file_transcripts)
     
     disinct_variant_count = len({f'{x.chromosome}-{x.position}-{x.reference}-{x.alt}' for x in annovar_records})
-    logger.debug(f'Read {disinct_variant_count} distinct variants and {len(annovar_records)} transcripts from annovar files')
+    logging.debug(f'Read {disinct_variant_count} distinct variants and {len(annovar_records)} transcripts from annovar files')
 
     # Merge like transcripts into a single annovar record 
     initial_size = len(annovar_records)
     annovar_records = annovarParser.merge(annovar_records)
 
-    logger.info(f"Merged {initial_size} transcripts down to {len(annovar_records)}")
+    logging.info(f"Merged {initial_size} transcripts down to {len(annovar_records)}")
     return annovar_records
 
         
@@ -92,12 +81,14 @@ def _main():
     '''
     main function
     '''
+    logging.config.dictConfig(TfxLogConfig().log_config)
+    
     args = _parse_args()
 
     annovar_file_names = [x.name for x in args.annovar_file]
     annovar_records = get_annovar_records(annovar_file_names)
 
-    logger.info(f"Writing {args.out_file.name}")    
+    logging.info(f"Writing {args.out_file.name}")    
     txEffCsv = TxEffCsv()
     txEffCsv.write_transcripts(args.out_file.name, annovar_records)
 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_ccds.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_ccds.py
@@ -9,6 +9,7 @@ import logging
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 from edu.ohsu.compbio.txeff.util.refseq_to_ccds import RefseqToCcds
 from enum import Enum
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 
 class CcdsMapFileType(Enum):
     '''
@@ -31,17 +32,7 @@ class TxEffCcds(object):
         self.refseq_to_ccds_file = refseq_to_ccds_file
         
         # Set up a logger for this class
-        logger = logging.getLogger(__name__)
-        logger.setLevel(logging.DEBUG)
-
-        stream_handler = logging.StreamHandler()
-        logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-        stream_format = logging.Formatter(logging_format)
-        stream_handler.setFormatter(stream_format)
-        stream_handler.setLevel(logging.INFO)
-        logger.addHandler(stream_handler)
-        self.logger = logger
+        self.logger = logging.getLogger(__name__)
 
     def _get_refseq_to_ccds_mappings(self):
         '''
@@ -135,6 +126,8 @@ def _parse_args():
 def _main():
     '''
     '''
+    logging.config.dictConfig(TfxLogConfig().log_config)
+    
     args = _parse_args()
     
     # Read transcripts that have been written to csv

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -5,22 +5,12 @@ Created on May 18, 2022
 '''
 
 import argparse
-import logging
+import logging.config
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
 VERSION = '0.2.5'
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-stream_handler = logging.StreamHandler()
-logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-stream_format = logging.Formatter(logging_format)
-stream_handler.setFormatter(stream_format)
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
 
 def _parse_args():
     '''
@@ -66,7 +56,10 @@ def _parse_args():
 def _main():
     '''
     main function
-    '''            
+    '''
+    logging.config.dictConfig(TfxLogConfig().log_config)
+    logging.info("cgd_tx_eff is starting...")
+    
     args = _parse_args()
 
     # Use tx_eff_annovar to read annovar records 
@@ -85,7 +78,3 @@ def _main():
 
 if __name__ == '__main__':
     _main()
-    
-    
-    
-    

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -9,7 +9,7 @@ import logging
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.2.4'
+VERSION = '0.2.5'
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -9,7 +9,7 @@ import logging
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.2.3'
+VERSION = '0.2.4'
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -9,7 +9,7 @@ import logging
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.2.2'
+VERSION = '0.2.3'
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
@@ -27,7 +27,7 @@ from typing import Iterable
 from edu.ohsu.compbio.annovar.annovar_parser import AnnovarVariantFunction
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 
-VERSION = '0.2.3'
+VERSION = '0.2.4'
 ASSEMBLY_VERSION = "GRCh37"
 
 logger = logging.getLogger(__name__)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
@@ -12,7 +12,7 @@ Created on Apr 20, 2022
 import argparse
 import hgvs.assemblymapper
 import hgvs.dataproviders.uta
-import logging
+import logging.config
 import os
 from collections import defaultdict
 from edu.ohsu.compbio.txeff.variant_transcript import VariantTranscript
@@ -26,20 +26,10 @@ from hgvs.exceptions import HGVSInvalidVariantError, HGVSUsageError, HGVSDataNot
 from typing import Iterable
 from edu.ohsu.compbio.annovar.annovar_parser import AnnovarVariantFunction
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 
 VERSION = '0.2.5'
 ASSEMBLY_VERSION = "GRCh37"
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-stream_handler = logging.StreamHandler()
-logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-stream_format = logging.Formatter(logging_format)
-stream_handler.setFormatter(stream_format)
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
 
 # These will need to be updated when we switch from GRCh37 to GRCh38
 CHROM_MAP = {'1': 'NC_000001.10', '2': 'NC_000002.11', '3': 'NC_000003.11', '4': 'NC_000004.11', '5': 'NC_000005.9',
@@ -111,12 +101,12 @@ def _lookup_hgvs_transcripts(variants: list):
     transcripts = []
     for variant in variants:
         variant_transcripts = __lookup_hgvs_transcripts(hgvs_parser, hdp, am, variant)
-        logger.info(f"HGVS found {len(variant_transcripts)} transcripts for {variant}")
+        logging.info(f"HGVS found {len(variant_transcripts)} transcripts for {variant}")
         
         # HGVS might not find any transcripts even though Annovar did 
         if len(variant_transcripts) == 0:
             # jDebug: how do you know there are transcripts known to annovar? 
-            logger.warning(f'HGVS could not find any transcripts for variant {variant} which has transcripts known to Annovar.')
+            logging.warning(f'HGVS could not find any transcripts for variant {variant} which has transcripts known to Annovar.')
         else:
             transcripts.extend(variant_transcripts)
     
@@ -126,12 +116,12 @@ def __lookup_hgvs_transcripts(hgvs_parser: hgvs.parser.Parser, hdp: UTABase, am:
     '''
     Use HGVS/UTA to return a list of the transcripts for a variant
     '''
-    logger.debug(f"Using HGVS/UTA to find transcripts for {variant}")
+    logging.debug(f"Using HGVS/UTA to find transcripts for {variant}")
     
     hgvs_chrom = CHROM_MAP.get(variant.chromosome)
     
     if hgvs_chrom == None:
-        logger.warning(f"Unknown chromosome: {variant.chromosome}-{variant.position}-{variant.reference}-{variant.alt}")
+        logging.warning(f"Unknown chromosome: {variant.chromosome}-{variant.position}-{variant.reference}-{variant.alt}")
         return []
     
     # Look up the variant using HGVS            
@@ -175,7 +165,7 @@ def __lookup_hgvs_transcripts(hgvs_parser: hgvs.parser.Parser, hdp: UTABase, am:
                 assert var_p.posedit == None, "A position is not expected with 'p.?'"                
             elif isinstance(var_p.posedit, hgvs.edit.AARefAlt):
                 # Some variants don't have any position information, and that is ok. Most of the time these are indels, as indicated by ``var_p.posedit.type``
-                logger.debug(f"HGVS variant does not have a position: ref={var_p.posedit.ref}, alt={var_p.posedit.alt}, type={var_p.posedit.type}, str={str(var_p.posedit)}. Keeping.")
+                logging.debug(f"HGVS variant does not have a position: ref={var_p.posedit.ref}, alt={var_p.posedit.alt}, type={var_p.posedit.type}, str={str(var_p.posedit)}. Keeping.")
             else:
                 variant_transcript.hgvs_amino_acid_position = var_p.posedit.pos.start.pos
             
@@ -192,21 +182,21 @@ def __lookup_hgvs_transcripts(hgvs_parser: hgvs.parser.Parser, hdp: UTABase, am:
                  
         except HGVSUsageError as e:
             if("non-coding transcript" in e.args[0]):
-                logger.info(f"Error caused by non-coding transcript {variant}. Transcript will have name and gene only: %s", str(e))
+                logging.info(f"Error caused by non-coding transcript {variant}. Transcript will have name and gene only: %s", str(e))
                 
                 # Add the transcript even though an exception was thrown. At least we have the transcript+gene. 
                 hgvs_transcripts.append(variant_transcript)
             else:
                 raise(e)
         except HGVSInvalidVariantError as e:            
-            logger.warning(f"Invalid variant {variant}: %s", str(e))
+            logging.warning(f"Invalid variant {variant}: %s", str(e))
             raise(e)
         except HGVSUnsupportedOperationError as e:
-            logger.warning(f"Invalid parameters while processing variant={variant}, var_g={var_g}, transcript={str(hgvs_transcript[0])}: %s", str(e))
+            logging.warning(f"Invalid parameters while processing variant={variant}, var_g={var_g}, transcript={str(hgvs_transcript[0])}: %s", str(e))
         except HGVSInvalidIntervalError as e:
-            logger.warning(f"Invalid variant interval {variant}: %s", str(e))
+            logging.warning(f"Invalid variant interval {variant}: %s", str(e))
         except HGVSDataNotAvailableError as e:
-            logger.warn(f"Unable to use HGVS to parse variant {variant}: %s", str(e))
+            logging.warn(f"Unable to use HGVS to parse variant {variant}: %s", str(e))
     
     return hgvs_transcripts
 
@@ -222,7 +212,7 @@ def _get_unmatched_annovar_transcripts(annovar_dict: defaultdict(list), hgvs_dic
         # Check the HGVS dictionary for a key matching the annovar key. If there is a match, then the annovar transcript has already  
         # been processed. If HGVS does not have the key then the annovar transcript has not been looked at.
         if hgvs_dict.get(transcript_key) == None:
-            logger.debug(f"Adding unmatched Annovar transcript(s) for {transcript_key}")
+            logging.debug(f"Adding unmatched Annovar transcript(s) for {transcript_key}")
             
             # Convert the AnnovarVariantFunction objects to VariantTranscript so all items in the list are of the same type. 
             for annovar_transcript in annovar_transcript_list:
@@ -230,7 +220,7 @@ def _get_unmatched_annovar_transcripts(annovar_dict: defaultdict(list), hgvs_dic
     
     for (transcript_key, hgvs_transcript_list) in hgvs_dict.items():
         if annovar_dict.get(transcript_key) == None:
-            logger.debug(f"Adding unmatched HGVS transcript(s) for {transcript_key}")
+            logging.debug(f"Adding unmatched HGVS transcript(s) for {transcript_key}")
             transcripts.extend(hgvs_transcript_list)
     
     return transcripts
@@ -282,9 +272,9 @@ def _merge_annovar_with_hgvs(annovar_transcripts: list, hgvs_transcripts: list, 
         
         annovar_matches = annovar_dict.get(transcript_key)
         if not annovar_matches:
-            logger.debug(f"HGVS {transcript_key} does not match any Annovar transcripts")
+            logging.debug(f"HGVS {transcript_key} does not match any Annovar transcripts")
         else:
-            logger.debug(f"Merging HGVS transcript with {len(annovar_matches)} Annovar transcripts having key {transcript_key}")
+            logging.debug(f"Merging HGVS transcript with {len(annovar_matches)} Annovar transcripts having key {transcript_key}")
             transcripts.append(_merge(transcript_key, hgvs_transcript, annovar_matches))
 
     # If matching is not required, then add unmatched Annovar transcripts to the final list
@@ -317,7 +307,7 @@ def _merge_into(transcript_key: str, new_transcript: VariantTranscript, hgvs_tra
     # Amino Acid Position
     ## Amino acid position is commonly different between HGVS and Annovar 
     if str(hgvs_transcript.hgvs_amino_acid_position) != str(annovar_transcript.hgvs_amino_acid_position):
-        logger.debug(f"HGVS and Annovar do not agree on amino acid position for {transcript_key}: {hgvs_transcript.hgvs_amino_acid_position} != {annovar_transcript.hgvs_amino_acid_position}")
+        logging.debug(f"HGVS and Annovar do not agree on amino acid position for {transcript_key}: {hgvs_transcript.hgvs_amino_acid_position} != {annovar_transcript.hgvs_amino_acid_position}")
 
     if _allow_merge(new_transcript.hgvs_amino_acid_position, hgvs_transcript.hgvs_amino_acid_position, transcript_key, 'hgvs_amino_acid_position'):
         new_transcript.hgvs_amino_acid_position = hgvs_transcript.hgvs_amino_acid_position 
@@ -325,7 +315,7 @@ def _merge_into(transcript_key: str, new_transcript: VariantTranscript, hgvs_tra
     # Base Position
     ## Base position may not match what HGVS says; can be empty; or will match between annovar and hgvs    
     if str(hgvs_transcript.hgvs_base_position) != str(annovar_transcript.hgvs_base_position):
-        logger.debug(f"HGVS and Annovar do not agree on base_position for {transcript_key}: {hgvs_transcript.hgvs_base_position} != {annovar_transcript.hgvs_base_position}")    
+        logging.debug(f"HGVS and Annovar do not agree on base_position for {transcript_key}: {hgvs_transcript.hgvs_base_position} != {annovar_transcript.hgvs_base_position}")    
     
     if _allow_merge(new_transcript.hgvs_base_position, hgvs_transcript.hgvs_base_position, transcript_key, 'hgvs_base_position'):
         new_transcript.hgvs_base_position = hgvs_transcript.hgvs_base_position
@@ -340,12 +330,12 @@ def _merge_into(transcript_key: str, new_transcript: VariantTranscript, hgvs_tra
     # Prefer annovar's gene, but annovar doesn't give us a gene for intron and utr; in those cases use hgvs's.        
     transcript_gene = annovar_transcript.hgnc_gene
     if _noneIfEmpty(annovar_transcript.hgnc_gene) == None and _noneIfEmpty(hgvs_transcript.hgnc_gene) == None:
-        logger.debug(f"Gene selection: Neither Annovar or HGVS have a gene for {transcript_key}") 
+        logging.debug(f"Gene selection: Neither Annovar or HGVS have a gene for {transcript_key}") 
     elif annovar_transcript.hgnc_gene == None:
-        logger.debug(f"Gene selection: Annovar did not provide a gene for {transcript_key}, using HGVS's: gene={hgvs_transcript.hgnc_gene}")            
+        logging.debug(f"Gene selection: Annovar did not provide a gene for {transcript_key}, using HGVS's: gene={hgvs_transcript.hgnc_gene}")            
         transcript_gene = hgvs_transcript.hgnc_gene
     elif annovar_transcript.hgnc_gene != hgvs_transcript.hgnc_gene:
-        logger.debug(f"Gene selection: Annovar and HGVS genes don't match for {transcript_key}: {annovar_transcript.hgnc_gene} != {hgvs_transcript.hgnc_gene}")
+        logging.debug(f"Gene selection: Annovar and HGVS genes don't match for {transcript_key}: {annovar_transcript.hgnc_gene} != {hgvs_transcript.hgnc_gene}")
     
     if _allow_merge(new_transcript.hgnc_gene, transcript_gene, transcript_key, 'hgnc_gene'):
         new_transcript.hgnc_gene = transcript_gene
@@ -355,7 +345,7 @@ def _merge_into(transcript_key: str, new_transcript: VariantTranscript, hgvs_tra
     assert hgvs_transcript.hgvs_c_dot != None or hgvs_transcript.refseq_transcript.startswith('NR_'), "The HGVS c. value is not supposed to be empty"
     
     if hgvs_transcript.hgvs_c_dot != annovar_transcript.hgvs_c_dot:
-        logger.debug(f"HGVS and Annovar do not agree on c_dot for {transcript_key}: {hgvs_transcript.hgvs_c_dot} != {annovar_transcript.hgvs_c_dot} ")
+        logging.debug(f"HGVS and Annovar do not agree on c_dot for {transcript_key}: {hgvs_transcript.hgvs_c_dot} != {annovar_transcript.hgvs_c_dot} ")
 
     if _allow_merge(new_transcript.hgvs_c_dot, hgvs_transcript.hgvs_c_dot, transcript_key, 'hgvs_c_dot'):
         new_transcript.hgvs_c_dot = hgvs_transcript.hgvs_c_dot
@@ -365,7 +355,7 @@ def _merge_into(transcript_key: str, new_transcript: VariantTranscript, hgvs_tra
     assert hgvs_transcript.hgvs_p_dot_one != None or hgvs_transcript.refseq_transcript.startswith('NR_')
     
     if hgvs_transcript.hgvs_p_dot_one != annovar_transcript.hgvs_p_dot_one:
-        logger.debug(f"HGVS and Annovar do not agree on hgvs_p_dot_one for {transcript_key}: {hgvs_transcript.hgvs_p_dot_one} != {annovar_transcript.hgvs_p_dot_one} ")
+        logging.debug(f"HGVS and Annovar do not agree on hgvs_p_dot_one for {transcript_key}: {hgvs_transcript.hgvs_p_dot_one} != {annovar_transcript.hgvs_p_dot_one} ")
 
     if _allow_merge(new_transcript.hgvs_p_dot_one, hgvs_transcript.hgvs_p_dot_one, transcript_key, 'hgvs_p_dot_one'):
         new_transcript.hgvs_p_dot_one = hgvs_transcript.hgvs_p_dot_one
@@ -374,7 +364,7 @@ def _merge_into(transcript_key: str, new_transcript: VariantTranscript, hgvs_tra
     assert hgvs_transcript.hgvs_p_dot_three != None or hgvs_transcript.refseq_transcript.startswith('NR_')
 
     if hgvs_transcript.hgvs_p_dot_three != annovar_transcript.hgvs_p_dot_three:
-        logger.debug(f"HGVS and Annovar do not agree on hgvs_p_dot_three for {transcript_key}: {hgvs_transcript.hgvs_p_dot_three} != {annovar_transcript.hgvs_p_dot_three} ")
+        logging.debug(f"HGVS and Annovar do not agree on hgvs_p_dot_three for {transcript_key}: {hgvs_transcript.hgvs_p_dot_three} != {annovar_transcript.hgvs_p_dot_three} ")
 
     if _allow_merge(new_transcript.hgvs_p_dot_three, hgvs_transcript.hgvs_p_dot_three, transcript_key, 'hgvs_p_dot_three'):
         new_transcript.hgvs_p_dot_three = hgvs_transcript.hgvs_p_dot_three
@@ -453,7 +443,7 @@ def get_summary(require_match: bool, annovar_transcripts: list, annovar_variants
         if annovar_rec.splicing == 'splicing' or annovar_rec.splicing == 'ncRNA_splicing':
             annovar_splice_variant_transcript_count += 1
         elif annovar_rec.splicing != None and annovar_rec.splicing != '':
-            logger.warning(f"Invalid value in splicing column: {annovar_rec.splicing}")
+            logging.warning(f"Invalid value in splicing column: {annovar_rec.splicing}")
 
         annovar_dict[key_maker(annovar_rec)].append(annovar_rec)
     
@@ -500,7 +490,7 @@ def get_summary(require_match: bool, annovar_transcripts: list, annovar_variants
     # Sanity check: The number of HGVS transcripts minus the count of merged HGVS transcripts is equal to the number of merged HGVS and annovar transcripts.    
     sanity_check_hgvs = (len(hgvs_transcripts) - unmatched_hgvs_transcript_count) == matched_annovar_and_hgvs_transcript_count
     if not sanity_check_hgvs:
-        logger.debug(f"Failed sanity check 'sanity_check_hgvs': {len(hgvs_transcripts)} - {unmatched_hgvs_transcript_count} != {matched_annovar_and_hgvs_transcript_count}")
+        logging.debug(f"Failed sanity check 'sanity_check_hgvs': {len(hgvs_transcripts)} - {unmatched_hgvs_transcript_count} != {matched_annovar_and_hgvs_transcript_count}")
     
     # Sanity check: The number of annovar transcripts minus the count of merged annovar transcripts, minus the number of 
     # splice variants is equal to the number of merged HGVS and annovar transcripts. Splice variants must be subtradcted because 
@@ -508,17 +498,17 @@ def get_summary(require_match: bool, annovar_transcripts: list, annovar_variants
     sanity_check_annovar = (len(annovar_transcripts) - unmatched_annovar_transcript_count - annovar_splice_variant_transcript_count) == matched_annovar_and_hgvs_transcript_count    
     # sanity_check_annovar = (len(annovar_transcripts) - unmatched_annovar_transcript_count) == matched_annovar_and_hgvs_transcript_count
     if not sanity_check_annovar:
-        logger.debug(f"Failed sanity check 'sanity_check_annovar': {len(annovar_transcripts)} - {unmatched_annovar_transcript_count} - {annovar_splice_variant_transcript_count} != {matched_annovar_and_hgvs_transcript_count}")
+        logging.debug(f"Failed sanity check 'sanity_check_annovar': {len(annovar_transcripts)} - {unmatched_annovar_transcript_count} - {annovar_splice_variant_transcript_count} != {matched_annovar_and_hgvs_transcript_count}")
 
     # Essential sanity check:  
     # Sanity check is currently off by just a little bit. 
     if not sanity_check_hgvs or not sanity_check_annovar:
-        logger.info(f'Failed sanity check: Total number of transcripts does not equal sum of matched, and unmatched ({sanity_check_hgvs} and {sanity_check_annovar}).')
+        logging.info(f'Failed sanity check: Total number of transcripts does not equal sum of matched, and unmatched ({sanity_check_hgvs} and {sanity_check_annovar}).')
          
     # Non-essential sanity check: all variants from annovar have at least one transcript in the final output
     sanity_check_variant_coverage = merged_distinct_variant_count == results['annovar_distinct_variant_count']
     if not sanity_check_variant_coverage:
-        logger.warning(f"Not all of the Annovar variants made it into the list of variant-transcripts ({merged_distinct_variant_count}/{results['annovar_distinct_variant_count']})")
+        logging.warning(f"Not all of the Annovar variants made it into the list of variant-transcripts ({merged_distinct_variant_count}/{results['annovar_distinct_variant_count']})")
 
     sanity_check = sanity_check_hgvs and sanity_check_annovar and sanity_check_variant_coverage
     results['sanity_check'] = sanity_check
@@ -531,18 +521,18 @@ def _log_summary(results: dict):
     Display summary of updated transcripts
     ''' 
     
-    logger.info(f"Argument require_match: {results['arg_require_match']}")
-    logger.info(f"Number of annovar transcripts: {results['annovar_transcript_count']}")
-    logger.info(f"Number of Annovar transcripts that are splice variants: {results['annovar_splice_variant_transcript_count']}")
-    logger.info(f"Number of distinct variants from Annovar: {results['annovar_distinct_variant_count']}")    
-    logger.info(f"Number of HGVS transcripts: {results['hgvs_transcript_count']}")
-    logger.info(f"Number of distinct variants from HGVS: {results['hgvs_distinct_variant_count']}")
-    logger.info(f"Number of transcripts matched in Annovar and HGVS: {results['matched_annovar_and_hgvs_transcript_count']}")
-    logger.info(f"Number of Annovar transcripts not matched with HGVS transcripts: {results['unmatched_annovar_transcript_count']}")
-    logger.info(f"Number of HGVS transcripts not matched with Annovar transcripts: {results['unmatched_hgvs_transcript_count']}")
-    logger.info(f"Number of distinct variants in merged transcript list: {results['merged_distinct_variant_count']}")
-    logger.info(f"Total number of transcripts in final list: {results['merged_transcript_count']}")
-    logger.info(f"Sanity check: {'Passed' if results['sanity_check'] else 'Failed' }")
+    logging.info(f"Argument require_match: {results['arg_require_match']}")
+    logging.info(f"Number of annovar transcripts: {results['annovar_transcript_count']}")
+    logging.info(f"Number of Annovar transcripts that are splice variants: {results['annovar_splice_variant_transcript_count']}")
+    logging.info(f"Number of distinct variants from Annovar: {results['annovar_distinct_variant_count']}")    
+    logging.info(f"Number of HGVS transcripts: {results['hgvs_transcript_count']}")
+    logging.info(f"Number of distinct variants from HGVS: {results['hgvs_distinct_variant_count']}")
+    logging.info(f"Number of transcripts matched in Annovar and HGVS: {results['matched_annovar_and_hgvs_transcript_count']}")
+    logging.info(f"Number of Annovar transcripts not matched with HGVS transcripts: {results['unmatched_annovar_transcript_count']}")
+    logging.info(f"Number of HGVS transcripts not matched with Annovar transcripts: {results['unmatched_hgvs_transcript_count']}")
+    logging.info(f"Number of distinct variants in merged transcript list: {results['merged_distinct_variant_count']}")
+    logging.info(f"Total number of transcripts in final list: {results['merged_transcript_count']}")
+    logging.info(f"Sanity check: {'Passed' if results['sanity_check'] else 'Failed' }")
 
 def _parse_args():
     '''
@@ -579,14 +569,14 @@ def identify_hgvs_datasources():
     Check the environment for definitions of HGVS' datasources and log the findings 
     '''
     if os.environ.get('HGVS_SEQREPO_DIR') == None:
-        logger.warning("The HGVS_SEQREPO_DIR environment variable is not defined. The remote seqrepo database will be used.")
+        logging.warning("The HGVS_SEQREPO_DIR environment variable is not defined. The remote seqrepo database will be used.")
     else:
-        logger.info(f"Using SeqRepo {os.environ.get('HGVS_SEQREPO_DIR')}")
+        logging.info(f"Using SeqRepo {os.environ.get('HGVS_SEQREPO_DIR')}")
     
     if os.environ.get('UTA_DB_URL') == None:
-        logger.warning("The UTA_DB_URL environment variable is not defined. The remote UTA database will be used.")
+        logging.warning("The UTA_DB_URL environment variable is not defined. The remote UTA database will be used.")
     else:
-        logger.info(f"Using UTA Database at {os.environ.get('UTA_DB_URL')}")
+        logging.info(f"Using UTA Database at {os.environ.get('UTA_DB_URL')}")
 
 def get_updated_hgvs_transcritpts(annovar_transcripts: list, require_match: bool):    
     '''
@@ -595,10 +585,10 @@ def get_updated_hgvs_transcritpts(annovar_transcripts: list, require_match: bool
     '''
     disinct_variants = {Variant(x.chromosome, x.position, x.reference, x.alt) for x in annovar_transcripts}
     
-    logger.debug(f'{len(disinct_variants)} distinct variants')
+    logging.debug(f'{len(disinct_variants)} distinct variants')
     
     hgvs_transcripts = _lookup_hgvs_transcripts(disinct_variants)
-    logger.debug(f'{len(hgvs_transcripts)} transcripts from HGVS')
+    logging.debug(f'{len(hgvs_transcripts)} transcripts from HGVS')
     
     merged_transcripts = _merge_annovar_with_hgvs(annovar_transcripts, hgvs_transcripts, require_match = require_match)
     
@@ -611,15 +601,17 @@ def _main():
     '''
     main function
     '''
+    logging.config.dictConfig(TfxLogConfig().log_config)
+    
     args = _parse_args()
     
     txEffCsv = TxEffCsv()    
     annovar_transcripts = txEffCsv.read_transcripts(args.in_file.name)
-    logger.debug(f'Read {len(annovar_transcripts)} Annovar transcripts from {args.in_file.name}')
+    logging.debug(f'Read {len(annovar_transcripts)} Annovar transcripts from {args.in_file.name}')
     
     merged_transcripts = get_updated_hgvs_transcritpts(annovar_transcripts, args.require_match)
     
-    logger.info(f"Writing {args.out_file.name}")
+    logging.info(f"Writing {args.out_file.name}")
     txEffCsv.write_transcripts(args.out_file.name, merged_transcripts)
 
 if __name__ == '__main__':

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
@@ -27,7 +27,7 @@ from typing import Iterable
 from edu.ohsu.compbio.annovar.annovar_parser import AnnovarVariantFunction
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 
-VERSION = '0.2.4'
+VERSION = '0.2.5'
 ASSEMBLY_VERSION = "GRCh37"
 
 logger = logging.getLogger(__name__)
@@ -172,6 +172,11 @@ def __lookup_hgvs_transcripts(hgvs_parser: hgvs.parser.Parser, hdp: UTABase, am:
                 variant_transcript.hgvs_amino_acid_position = var_p.posedit.pos.start.pos
             
             variant_transcript.hgvs_base_position = var_c.posedit.pos.start.base
+            
+            # jDebug
+            if variant_transcript.hgvs_base_position and type(variant_transcript.hgvs_base_position) is not int:
+                print(variant_transcript.hgvs_base_position)
+
             variant_transcript.hgvs_c_dot = c_dot
             variant_transcript.hgvs_p_dot_one = var_p1
             variant_transcript.hgvs_p_dot_three = var_p3

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
@@ -121,7 +121,7 @@ def _lookup_hgvs_transcripts(variants: list):
             transcripts.extend(variant_transcripts)
     
     return transcripts
-        
+
 def __lookup_hgvs_transcripts(hgvs_parser: hgvs.parser.Parser, hdp: UTABase, am: hgvs.assemblymapper.AssemblyMapper, variant: Variant):
     '''
     Use HGVS/UTA to return a list of the transcripts for a variant
@@ -284,7 +284,7 @@ def _merge_annovar_with_hgvs(annovar_transcripts: list, hgvs_transcripts: list, 
 def _merge(transcript_key: str, hgvs_transcript: VariantTranscript, annovar_transcripts: Iterable[VariantTranscript]):
     '''
     Combine Annovar and HGVS information relating to the same transcript into a single record.  
-    '''    
+    '''
     new_transcript = VariantTranscript(hgvs_transcript.chromosome, hgvs_transcript.position, hgvs_transcript.reference, hgvs_transcript.alt)
 
     for annovar_transcript in annovar_transcripts:
@@ -327,7 +327,7 @@ def _merge_into(transcript_key: str, new_transcript: VariantTranscript, hgvs_tra
     # Gene
     # Prefer annovar's gene, but annovar doesn't give us a gene for intron and utr; in those cases use hgvs's.        
     transcript_gene = annovar_transcript.hgnc_gene
-    if _noneIfEmpty(annovar_transcript.hgnc_gene) == None and _noneIfEmpty(annovar_transcript.hgnc_gene) == None:
+    if _noneIfEmpty(annovar_transcript.hgnc_gene) == None and _noneIfEmpty(hgvs_transcript.hgnc_gene) == None:
         logger.debug(f"Gene selection: Neither Annovar or HGVS have a gene for {transcript_key}") 
     elif annovar_transcript.hgnc_gene == None:
         logger.debug(f"Gene selection: Annovar did not provide a gene for {transcript_key}, using HGVS's: gene={hgvs_transcript.hgnc_gene}")            

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
@@ -27,7 +27,7 @@ from typing import Iterable
 from edu.ohsu.compbio.annovar.annovar_parser import AnnovarVariantFunction
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 
-VERSION = '0.0.1'
+VERSION = '0.2.3'
 ASSEMBLY_VERSION = "GRCh37"
 
 logger = logging.getLogger(__name__)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
@@ -27,7 +27,7 @@ stream_handler.setFormatter(stream_format)
 stream_handler.setLevel(logging.DEBUG)
 logger.addHandler(stream_handler)
 
-VERSION = '0.0.1'
+VERSION = '0.2.4'
 
 class TranscriptEffect(Enum):
     '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
@@ -85,7 +85,7 @@ def _read_vcf(vcf_filename: str):
     
     for vcf_record in vcf_reader:
         if len(vcf_record.ALT) > 1:
-            raise Exception(f'VCF variants must have just one ALT allel: {vcf_record.CHROM}-{vcf_record.POS}-{vcf_record.REF}-{vcf_record.ALT}')
+            raise Exception(f'VCF variants must have just one ALT allele: {vcf_record.CHROM}-{vcf_record.POS}-{vcf_record.REF}-{vcf_record.ALT}')
         
         variant = Variant(vcf_record.CHROM, vcf_record.POS, vcf_record.REF, vcf_record.ALT[0].value)
 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
@@ -7,21 +7,11 @@ joins the two so we can compare the nomenclature used in transcript effects with
 @author: pleyte
 '''
 import argparse
-import logging
+import logging.config
 import csv
 import vcfpy
 from edu.ohsu.compbio.txeff.tx_eff_vcf import TranscriptEffect
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
-
-stream_handler = logging.StreamHandler()
-logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-stream_format = logging.Formatter(logging_format)
-stream_handler.setFormatter(stream_format)
-stream_handler.setLevel(logging.DEBUG)
-logger.addHandler(stream_handler)
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 
 def find_in_vcf(chromosome: str, position_start: int, position_end: int, ref: str, alt: str, vcf_reader: vcfpy.reader.Reader):
     '''
@@ -29,7 +19,7 @@ def find_in_vcf(chromosome: str, position_start: int, position_end: int, ref: st
     '''
     chromosome_number = chromosome[3:] if chromosome.startswith("chr") else chromosome
     if position_start > position_end:
-        logger.warning("Unable to search for variant because {position_start}>{position_end}: {chromosome}-{position_start}-{ref}-{alt}")
+        logging.warning("Unable to search for variant because {position_start}>{position_end}: {chromosome}-{position_start}-{ref}-{alt}")
         return None
 
     vcf_records = [] 
@@ -37,18 +27,18 @@ def find_in_vcf(chromosome: str, position_start: int, position_end: int, ref: st
     search_string = f"{chromosome_number}:{position_start}-{position_end}"
     
     for record in vcf_reader.fetch(search_string):
-        logger.debug(f"Comparing {chromosome_number}-{position_start}-{ref}-{alt} with {record.CHROM}-{record.POS}-{record.REF}-{record.ALT[0].value}")
+        logging.debug(f"Comparing {chromosome_number}-{position_start}-{ref}-{alt} with {record.CHROM}-{record.POS}-{record.REF}-{record.ALT[0].value}")
         if position_start == record.POS and ref == record.REF and alt == record.ALT[0].value:
             vcf_records.append(record)
     
     if(len(vcf_records) == 0):
-        logger.debug(f"The VCF does not have a row matching {chromosome_number}-{position_start}-{ref}-{alt}")
+        logging.debug(f"The VCF does not have a row matching {chromosome_number}-{position_start}-{ref}-{alt}")
     elif(len(vcf_records) > 1):
-        logger.error(f"The VCF has more than one row matching {chromosome_number}-{position_start}-{ref}-{alt}. Skipping.")
+        logging.error(f"The VCF has more than one row matching {chromosome_number}-{position_start}-{ref}-{alt}. Skipping.")
     elif(len(record.ALT) > 1):
-        logger.error(f"The matching VCF record has more than one ALT value: {chromosome_number}-{position_start}-{ref}-{alt} ALT={record.ALT}")
+        logging.error(f"The matching VCF record has more than one ALT value: {chromosome_number}-{position_start}-{ref}-{alt} ALT={record.ALT}")
     else:
-        logger.debug(f"Found {chromosome_number}-{position_start}-{ref}-{alt}")
+        logging.debug(f"Found {chromosome_number}-{position_start}-{ref}-{alt}")
         return vcf_records[0]
 
     return None
@@ -62,10 +52,10 @@ def process(vcf_filename: str, csv_export_filename: str, csv_out_filename: str):
                   'tfx_exon', 'tfx_hgnc_gene', 'tfx_hgvs_c_dot', 'tfx_hgvs_p_dot_one', 'tfx_hgvs_p_dot_three', 
                   'tfx_splicing', 'tfx_refseq_transcript', 'tfx_protein_transcript']
     
-    logger.info(f"Reading {vcf_filename}")
+    logging.info(f"Reading {vcf_filename}")
     vcf_reader = vcfpy.Reader.from_path(vcf_filename)
     
-    logger.info(f"Reading {csv_export_filename}")
+    logging.info(f"Reading {csv_export_filename}")
     
     with open(csv_export_filename) as csv_export_file, open(csv_out_filename, "w") as csv_out_file:
         # Open the variant export csv 
@@ -77,21 +67,21 @@ def process(vcf_filename: str, csv_export_filename: str, csv_out_filename: str):
         
         # Iterate over each entry in the export file 
         for export_row in export_reader:
-            logger.debug(f"Looking for {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']}")
+            logging.debug(f"Looking for {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']}")
             
             vc = find_in_vcf(export_row['chromosome'], int(export_row['position_start']), int(export_row['position_end']), export_row['reference_base'], export_row['variant_base'], vcf_reader)
             if (vc == None):
-                logger.info(f"Unable to find genotype {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']} in vcf")
+                logging.info(f"Unable to find genotype {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']} in vcf")
                 continue
             
             if vc.INFO.get(TranscriptEffect.TFX_VARIANT_EFFECT.value) == None:
-                logger.info(f"Variant does not have variant effects: {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']}")
+                logging.info(f"Variant does not have variant effects: {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']}")
                 continue
             
             # Write row(s) related to this genotype to the csv 
             write(csv_out_writer, export_row, vc)
 
-    logger.info(f"Wrote {csv_out_filename}")
+    logging.info(f"Wrote {csv_out_filename}")
 
 def write(csv_writer, export_row, vc: vcfpy.record.Record):
     '''
@@ -156,6 +146,8 @@ def _main():
     '''
     main function
     '''
+    logging.config.dictConfig(TfxLogConfig().utility_config)
+    
     args = _parse_args()
     process(args.vcf.name, args.export_csv.name, args.out_file.name)
 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
@@ -55,7 +55,7 @@ def find_in_vcf(chromosome: str, position_start: int, position_end: int, ref: st
 
 def process(vcf_filename: str, csv_export_filename: str, csv_out_filename: str):
     out_fields = ['genomic_variant_id', 'chromosome', 'position', 'reference', 'alt',
-                  'cgd_variant_effect', 'cgd_variant_type', 'cgd_hgvs_amino_acid_position', 'cgd_hgvs_base_position', 
+                  'cgd_variant_effect', 'cgd_variant_type', 'cgd_stop_gain_loss', 'cgd_hgvs_amino_acid_position', 'cgd_hgvs_base_position', 
                   'cgd_exon', 'cgd_hgnc_gene', 'cgd_primary_gene', 'cgd_hgvs_c_dot', 'cgd_hgvs_p_dot_one', 'cgd_hgvs_p_dot_three', 
                   'cgd_splicing', 'cgd_refseq_transcript', 'cgd_protein_transcript',
                   'tfx_variant_effect', 'tfx_variant_type', 'tfx_hgvs_amino_acid_position', 'tfx_hgvs_base_position', 
@@ -100,6 +100,7 @@ def write(csv_writer, export_row, vc: vcfpy.record.Record):
                          export_row['chromosome'], export_row['position_start'], export_row['reference_base'], export_row['variant_base'],
                          export_row['protein_variant_type'],                          # 'cgd_variant_effect' - annovar variant_effect is cgd's protein variant type
                          export_row['genomic_variant_type'],                          # 'cgd_variant_type'
+                         export_row['stop_gain_loss'],                                # 'cgd_stop_gain_loss'
                          export_row['amino_acid_position'],                           # 'cgd_hgvs_amino_acid_position' 
                          export_row['base_pair_position'],                            # 'cgd_hgvs_base_position', 
                          export_row['exon'],                                          # 'cgd_exon'
@@ -110,7 +111,7 @@ def write(csv_writer, export_row, vc: vcfpy.record.Record):
                          export_row['genotype_amino_acid_threel'],                    # 'cgd_hgvs_p_dot_three' 
                          export_row['splice_site_relationship'],                      # 'cgd_splicing'
                          export_row['cdna_transcript'],                               # 'cgd_refseq_transcript'
-                         export_row['protein_transcript'],                           # 'cgd_protein_transcript'
+                         export_row['protein_transcript'],                            # 'cgd_protein_transcript'
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_VARIANT_EFFECT.value]]),         # 'tfx_variant_effect'
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_VARIANT_TYPE.value]]),           # 'tfx_variant_type', 
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_AMINO_ACID_POSITION.value]]),    # 'tfx_hgvs_amino_acid_position', 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
@@ -1,7 +1,7 @@
 '''
 Created on Jul 1, 2022
 
-Takes as input a VCF that has been updated with transcript effects, and a heme variant export CSV, and 
+Takes as input a VCF that has been updated with transcript effects, and a variant export CSV, and 
 joins the two so we can compare the nomenclature used in transcript effects with what is currently in CGD. 
 
 @author: pleyte
@@ -53,7 +53,7 @@ def find_in_vcf(chromosome: str, position_start: int, position_end: int, ref: st
 
     return None
 
-def process(vcf_filename: str, csv_heme_filename: str, csv_out_filename: str):
+def process(vcf_filename: str, csv_export_filename: str, csv_out_filename: str):
     out_fields = ['genomic_variant_id', 'chromosome', 'position', 'reference', 'alt',
                   'cgd_variant_effect', 'cgd_variant_type', 'cgd_hgvs_amino_acid_position', 'cgd_hgvs_base_position', 
                   'cgd_exon', 'cgd_hgnc_gene', 'cgd_primary_gene', 'cgd_hgvs_c_dot', 'cgd_hgvs_p_dot_one', 'cgd_hgvs_p_dot_three', 
@@ -65,52 +65,52 @@ def process(vcf_filename: str, csv_heme_filename: str, csv_out_filename: str):
     logger.info(f"Reading {vcf_filename}")
     vcf_reader = vcfpy.Reader.from_path(vcf_filename)
     
-    logger.info(f"Reading {csv_heme_filename}")
+    logger.info(f"Reading {csv_export_filename}")
     
-    with open(csv_heme_filename) as csv_heme_file, open(csv_out_filename, "w") as csv_out_file:
-        # Open the input heme variant export csv 
-        heme_reader = csv.DictReader(csv_heme_file)
+    with open(csv_export_filename) as csv_export_file, open(csv_out_filename, "w") as csv_out_file:
+        # Open the variant export csv 
+        export_reader = csv.DictReader(csv_export_file)
 
         # Open the output csv
         csv_out_writer = csv.writer(csv_out_file)
         csv_out_writer.writerow(out_fields)
         
-        # Iterate over each entry in the heme export 
-        for heme_row in heme_reader:
-            logger.debug(f"Looking for {heme_row['chromosome']}-{heme_row['position_start']}-{heme_row['reference_base']}-{heme_row['variant_base']}")
+        # Iterate over each entry in the export file 
+        for export_row in export_reader:
+            logger.debug(f"Looking for {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']}")
             
-            vc = find_in_vcf(heme_row['chromosome'], int(heme_row['position_start']), int(heme_row['position_end']), heme_row['reference_base'], heme_row['variant_base'], vcf_reader)
+            vc = find_in_vcf(export_row['chromosome'], int(export_row['position_start']), int(export_row['position_end']), export_row['reference_base'], export_row['variant_base'], vcf_reader)
             if (vc == None):
-                logger.info(f"Unable to find genotype {heme_row['chromosome']}-{heme_row['position_start']}-{heme_row['reference_base']}-{heme_row['variant_base']} in vcf")
+                logger.info(f"Unable to find genotype {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']} in vcf")
                 continue
             
             if vc.INFO.get(TranscriptEffect.TFX_VARIANT_EFFECT.value) == None:
-                logger.info(f"Variant does not have variant effects: {heme_row['chromosome']}-{heme_row['position_start']}-{heme_row['reference_base']}-{heme_row['variant_base']}")
+                logger.info(f"Variant does not have variant effects: {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']}")
                 continue
             
             # Write row(s) related to this genotype to the csv 
-            write(csv_out_writer, heme_row, vc)
+            write(csv_out_writer, export_row, vc)
 
     logger.info(f"Wrote {csv_out_filename}")
 
-def write(csv_writer, heme_row, vc: vcfpy.record.Record):
+def write(csv_writer, export_row, vc: vcfpy.record.Record):
     '''
     '''    
-    csv_writer.writerow([heme_row['genomic_variant_id'],
-                         heme_row['chromosome'], heme_row['position_start'], heme_row['reference_base'], heme_row['variant_base'],
-                         heme_row['protein_variant_type'],                          # 'cgd_variant_effect' - annovar variant_effect is cgd's protein variant type
-                         heme_row['genomic_variant_type'],                          # 'cgd_variant_type'
-                         heme_row['amino_acid_position'],                           # 'cgd_hgvs_amino_acid_position' 
-                         heme_row['base_pair_position'],                            # 'cgd_hgvs_base_position', 
-                         heme_row['exon'],                                          # 'cgd_exon'
-                         heme_row['genes'],                                         # 'cgd_hgnc_gene'
-                         heme_row['primary_gene'],                                   # 'cgd_primary_gene'
-                         heme_row['genotype_cdna'],                                 # 'cgd_hgvs_c_dot'
-                         heme_row['genotype_amino_acid_onel'],                      # 'cgd_hgvs_p_dot_one' 
-                         heme_row['genotype_amino_acid_threel'],                    # 'cgd_hgvs_p_dot_three' 
-                         heme_row['splice_site_relationship'],                      # 'cgd_splicing'
-                         heme_row['cdna_transcript'],                               # 'cgd_refseq_transcript'
-                         heme_row['protein_transcript'],                           # 'cgd_protein_transcript'
+    csv_writer.writerow([export_row['genomic_variant_id'],
+                         export_row['chromosome'], export_row['position_start'], export_row['reference_base'], export_row['variant_base'],
+                         export_row['protein_variant_type'],                          # 'cgd_variant_effect' - annovar variant_effect is cgd's protein variant type
+                         export_row['genomic_variant_type'],                          # 'cgd_variant_type'
+                         export_row['amino_acid_position'],                           # 'cgd_hgvs_amino_acid_position' 
+                         export_row['base_pair_position'],                            # 'cgd_hgvs_base_position', 
+                         export_row['exon'],                                          # 'cgd_exon'
+                         export_row['genes'],                                         # 'cgd_hgnc_gene'
+                         export_row['primary_gene'],                                   # 'cgd_primary_gene'
+                         export_row['genotype_cdna'],                                 # 'cgd_hgvs_c_dot'
+                         export_row['genotype_amino_acid_onel'],                      # 'cgd_hgvs_p_dot_one' 
+                         export_row['genotype_amino_acid_threel'],                    # 'cgd_hgvs_p_dot_three' 
+                         export_row['splice_site_relationship'],                      # 'cgd_splicing'
+                         export_row['cdna_transcript'],                               # 'cgd_refseq_transcript'
+                         export_row['protein_transcript'],                           # 'cgd_protein_transcript'
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_VARIANT_EFFECT.value]]),         # 'tfx_variant_effect'
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_VARIANT_TYPE.value]]),           # 'tfx_variant_type', 
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_AMINO_ACID_POSITION.value]]),    # 'tfx_hgvs_amino_acid_position', 
@@ -130,15 +130,15 @@ def _parse_args():
     '''
     Validate and return command line arguments.
     '''
-    parser = argparse.ArgumentParser(description='Join a VCF containing transcript effects with a heme variant export')
+    parser = argparse.ArgumentParser(description='Join a VCF containing transcript effects with a CSV from variant export')
 
     parser.add_argument('-v', '--vcf',  
                         help='Input VCF.bgz containing transcript effects (index must also exist)',
                         type=argparse.FileType('r'),
                         required=True)
 
-    parser.add_argument('-c', '--heme_csv',  
-                        help='Heme variant export',
+    parser.add_argument('-c', '--export_csv',  
+                        help='Variant export CSV (use variant_transcripts.sql to generate the csv)',
                         type=argparse.FileType('r'),
                         required=True)
         
@@ -156,7 +156,7 @@ def _main():
     main function
     '''
     args = _parse_args()
-    process(args.vcf.name, args.heme_csv.name, args.out_file.name)
+    process(args.vcf.name, args.export_csv.name, args.out_file.name)
 
 if __name__ == '__main__':
     _main()

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
@@ -54,9 +54,9 @@ def find_in_vcf(chromosome: str, position_start: int, position_end: int, ref: st
     return None
 
 def process(vcf_filename: str, csv_heme_filename: str, csv_out_filename: str):
-    out_fields = ['chromosome', 'position', 'reference', 'alt',
+    out_fields = ['genomic_variant_id', 'chromosome', 'position', 'reference', 'alt',
                   'cgd_variant_effect', 'cgd_variant_type', 'cgd_hgvs_amino_acid_position', 'cgd_hgvs_base_position', 
-                  'cgd_exon', 'cgd_hgnc_gene', 'cgd_hgvs_c_dot', 'cgd_hgvs_p_dot_one', 'cgd_hgvs_p_dot_three', 
+                  'cgd_exon', 'cgd_hgnc_gene', 'cgd_primary_gene', 'cgd_hgvs_c_dot', 'cgd_hgvs_p_dot_one', 'cgd_hgvs_p_dot_three', 
                   'cgd_splicing', 'cgd_refseq_transcript', 'cgd_protein_transcript',
                   'tfx_variant_effect', 'tfx_variant_type', 'tfx_hgvs_amino_acid_position', 'tfx_hgvs_base_position', 
                   'tfx_exon', 'tfx_hgnc_gene', 'tfx_hgvs_c_dot', 'tfx_hgvs_p_dot_one', 'tfx_hgvs_p_dot_three', 
@@ -96,19 +96,21 @@ def process(vcf_filename: str, csv_heme_filename: str, csv_out_filename: str):
 def write(csv_writer, heme_row, vc: vcfpy.record.Record):
     '''
     '''    
-    csv_writer.writerow([heme_row['chromosome'], heme_row['position_start'], heme_row['reference_base'], heme_row['variant_base'],
+    csv_writer.writerow([heme_row['genomic_variant_id'],
+                         heme_row['chromosome'], heme_row['position_start'], heme_row['reference_base'], heme_row['variant_base'],
                          heme_row['protein_variant_type'],                          # 'cgd_variant_effect' - annovar variant_effect is cgd's protein variant type
                          heme_row['genomic_variant_type'],                          # 'cgd_variant_type'
                          heme_row['amino_acid_position'],                           # 'cgd_hgvs_amino_acid_position' 
                          heme_row['base_pair_position'],                            # 'cgd_hgvs_base_position', 
-                         heme_row['exons'],                                         # 'cgd_exon'
-                         heme_row['gene'],                                          # 'cgd_hgnc_gene'
+                         heme_row['exon'],                                          # 'cgd_exon'
+                         heme_row['genes'],                                         # 'cgd_hgnc_gene'
+                         heme_row['primary_gene'],                                   # 'cgd_primary_gene'
                          heme_row['genotype_cdna'],                                 # 'cgd_hgvs_c_dot'
                          heme_row['genotype_amino_acid_onel'],                      # 'cgd_hgvs_p_dot_one' 
                          heme_row['genotype_amino_acid_threel'],                    # 'cgd_hgvs_p_dot_three' 
                          heme_row['splice_site_relationship'],                      # 'cgd_splicing'
-                         heme_row['transcripts'],                                   # 'cgd_refseq_transcript'
-                         heme_row['protein_transcripts'],                           # 'cgd_protein_transcript'                        
+                         heme_row['cdna_transcript'],                               # 'cgd_refseq_transcript'
+                         heme_row['protein_transcript'],                           # 'cgd_protein_transcript'
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_VARIANT_EFFECT.value]]),         # 'tfx_variant_effect'
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_VARIANT_TYPE.value]]),           # 'tfx_variant_type', 
                         ' / '.join([x for x in vc.INFO[TranscriptEffect.TFX_AMINO_ACID_POSITION.value]]),    # 'tfx_hgvs_amino_acid_position', 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/refseq_to_ccds.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/refseq_to_ccds.py
@@ -11,6 +11,7 @@ import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, FileType
 from collections import defaultdict
 from BCBio import GFF
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 
 __version__ = 0.1
 
@@ -25,18 +26,8 @@ class RefseqToCcds(object):
         '''
         Constructor
         '''
-        logger = logging.getLogger(__name__)
-        logger.setLevel(logging.DEBUG)
+        self.logger = logging.getLogger(__name__)
 
-        stream_handler = logging.StreamHandler()
-        logging_format = '%(levelname)s: [%(filename)s:%(lineno)s - %(funcName)s()]: %(message)s'
-
-        stream_format = logging.Formatter(logging_format)
-        stream_handler.setFormatter(stream_format)
-        stream_handler.setLevel(logging.INFO)
-        logger.addHandler(stream_handler)
-        self.logger = logger
-        
     def get_mappings_from_gff(self, gff_file_name: str):
         '''
         Read the GFF file and return all refseq-to-ccds mappings 
@@ -104,6 +95,8 @@ class RefseqToCcds(object):
         self.logger.info(f"Wrote {len(refSeq_to_ccds)} refseq-to-cccds mappings to {csv_file_name}")
 
 def main():
+    logging.config.dictConfig(TfxLogConfig().log_config)
+    
     parser = ArgumentParser(description='', formatter_class=RawDescriptionHelpFormatter)
     parser.add_argument("-c", "--csv", help="CSV file to write out RefSeq-to-CCDS mappings", type=FileType('w'), required=True)
     parser.add_argument("-g", "--gff", help="GFF file to read RefSeq-to-CCDS mappings", type=FileType('r'), required=True)

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/tfx_log_config.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/tfx_log_config.py
@@ -1,0 +1,81 @@
+'''
+Created on Feb. 14, 2023
+Logger configurations that can be passed to the logging.config.dictConfig configurator.
+@author: pleyte
+'''
+
+class TfxLogConfig(object):
+    '''
+    classdocs
+    '''
+
+
+    def __init__(self):
+        '''
+        Constructor
+        '''
+        # Configuration for the Transcript Effects tool 
+        self.log_config = { 
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'standard': { 
+                    'format': '%(levelname)s: %(name)s::%(module)s:%(lineno)s: %(message)s'
+                },
+            },
+            'handlers': {
+                'default': {                     
+                    'formatter': 'standard',
+                    'class': 'logging.handlers.RotatingFileHandler',
+                    'filename': 'cgd_tx_eff.log', 
+                    'mode': 'a',
+                    'maxBytes': 10485760,
+                    'backupCount': 10
+                },
+            },
+            'loggers': { 
+                '': {  # root logger
+                    'handlers': ['default'],
+                    'level': 'DEBUG',
+                    'propagate': False
+                },
+                'edu.ohsu.compbio.txeff': { 
+                    'level': 'DEBUG',
+                    'propagate': False,
+                    'handlers': ['default'],
+                },
+            } 
+        }
+        
+        # Configuration for helper utilties in this source tree 
+        self.utility_config = { 
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'standard': { 
+                    'format': '%(levelname)s: %(name)s::%(module)s:%(lineno)s: %(message)s'
+                },
+            },
+            'handlers': {
+                'default': {                     
+                    'formatter': 'standard',
+                    'class': 'logging.StreamHandler',
+                    'stream': 'ext://sys.stdout',
+                },
+            },
+            'loggers': { 
+                '': {  # root logger
+                    'handlers': ['default'],
+                    'level': 'DEBUG',
+                    'propagate': False
+                },
+                'edu.ohsu.compbio.txeff': { 
+                    'level': 'DEBUG',
+                    'propagate': False,
+                    'handlers': ['default'],
+                },
+            } 
+        }
+        
+        
+        


### PR DESCRIPTION
This branch has the latest code changes that resulted from processing production VCFs with the cgd_tfx_eff.py tool. 

- Created ``compare_cgd_tfx.py`` that we are using to compare production nomenclature and effects with the new values coming from the tfx tool. 
- Handle situation where Annovar only generates one result file. Up until now Annovar always generated both annovar.variant_function and annovar.exonic_variant_function; but sometimes there's only one. 
- Base position was always being handled as an integer, but sometimes it is an offset. 
- In tx_eff_hgvs.py I reorganised the code so that whenthe AssemblyMapper is passed an NR_ transcript and throws an exception, a transcript+gene is still saved. 