### PR TITLE
BIO-626 - Lookup gene in UTA when annovar doesn't provide one

### DIFF
--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -6,11 +6,12 @@ Created on May 18, 2022
 
 import argparse
 import logging.config
+import time
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.3.3'
+VERSION = '0.3.5'
 
 def _parse_args():
     '''
@@ -55,7 +56,8 @@ def _main():
     main function
     '''
     logging.config.dictConfig(TfxLogConfig().log_config)
-    logging.info("cgd_tx_eff is starting...")
+    print("tfx_cgd is starting...")
+    start_time = time.time()
     
     args = _parse_args()
 
@@ -72,7 +74,13 @@ def _main():
      
     # Use tx_eff_vcf to write the transcript effects to a VCF
     tx_eff_vcf.create_vcf_with_transcript_effects(args.in_vcf.name, args.out_vcf.name, merged_transcripts)
+    
     print(f"Wrote {len(merged_transcripts)} transcripts to {args.out_vcf.name}")
+    
+    end_time = time.time()
+    total_time = end_time - start_time
+    time_str = time.strftime("%Mm:%Ss", time.gmtime(total_time))
+    print(f"Completed in {time_str}")
 
 if __name__ == '__main__':
     _main()

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.4" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.5" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>

--- a/cgd_tx_eff/tfx_cgd_comparison.xml
+++ b/cgd_tx_eff/tfx_cgd_comparison.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd_comparison" name="Tfx Comparison with CGD" version="0.4.2" >
+<tool id="tfx_cgd_comparison" name="Tfx Comparison with CGD" version="0.4.3" >
   <description>
     Generate a CSV for comparison of transcripts and nomenclature in CGD with the values found in the VCF produced by tx_eff_control.py.
   </description>


### PR DESCRIPTION
Annovar doesn't supply the a gene when transcript is intronic or UTR. Use UTA to find gene when annovar doesn't provide it. 