### PR TITLE
BIO-628 - Tfx is labeling indels as deletions 

### DIFF
--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/avinput2vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/avinput2vcf.py
@@ -95,7 +95,7 @@ def _write_vcf(vcf_file_name: str, variants: list):
         vcf_file.write('#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tabcd-123\n')
         
         for variant in variants:            
-            vcf_file.write(f"{variant.chromosome}\t{variant.startPos}\t{variant.dbSnpId}\t{variant.ref}\t{variant.alt}\t1.0\tPON\tx=y\tGT\t0/0\t\n")
+            vcf_file.write(f"{variant.chromosome}\t{variant.startPos}\t{variant.dbSnpId}\t{variant.ref}\t{variant.alt}\t1.0\tPON\tx=y\tGT\t0/0\n")
 
 def _main():
     '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -11,7 +11,7 @@ from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.3.5'
+VERSION = '0.3.7'
 
 def _parse_args():
     '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -11,7 +11,7 @@ from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.3.7'
+VERSION = '0.3.8'
 
 def _parse_args():
     '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
@@ -60,14 +60,7 @@ def _correct_indel_coords(pos, ref, alt):
         change = '>'.join([ref, alt])
         new_pos = str(pos) + change
         return new_pos
-    elif lref == lalt:
-        # Multi-nucleotide substitution case
-        # NG_012232.1: g.12_13delinsTG
-        new_start = str(pos)
-        new_end = str(int(pos) + lref - 1)
-        new_pos = '_'.join([new_start, new_end]) + 'delins' + alt
-        return new_pos
-    elif lref > lalt:
+    elif lalt == 1 and lref > lalt:
         # Deletion case
         shift = lref - lalt
         if shift == 1:
@@ -78,15 +71,22 @@ def _correct_indel_coords(pos, ref, alt):
             new_end = str(int(pos) + shift)
             new_pos = '_'.join([new_start, new_end]) + 'del'
             return new_pos
-    elif lalt > lref:
+    elif lref == 1 and lalt > lref:
         # Insertion case
         new_start = str(pos)
         new_end = str(int(pos) + 1)
         new_pos = '_'.join([new_start, new_end]) + 'ins' + alt[1:]
         return new_pos
+    elif lref > 1 and lalt > 1:
+        # Multi-nucleotide substitution case
+        # NG_012232.1: g.12_13delinsTG
+        new_start = str(pos)
+        new_end = str(int(pos) + lref - 1)
+        new_pos = '_'.join([new_start, new_end]) + 'delins' + alt
+        return new_pos
     else:
         # OTHER case
-        raise Exception(f"Change type not supported: {pos}:{ref}>{alt}")
+        print("Change type not supported: " + pos + ':' + ref + '>' + alt + '\n')
         
 def _lookup_hgvs_transcripts(annovar_variants: list):
     '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
@@ -27,7 +27,7 @@ from edu.ohsu.compbio.annovar.annovar_parser import AnnovarVariantFunction
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 
-VERSION = '0.3.5'
+VERSION = '0.3.8'
 ASSEMBLY_VERSION = "GRCh37"
 
 # These will need to be updated when we switch from GRCh37 to GRCh38
@@ -85,8 +85,7 @@ def _correct_indel_coords(pos, ref, alt):
         new_pos = '_'.join([new_start, new_end]) + 'delins' + alt
         return new_pos
     else:
-        # OTHER case
-        print("Change type not supported: " + pos + ':' + ref + '>' + alt + '\n')
+        raise Exception("Unknown change type: " + pos + ':' + ref + '>' + alt)
         
 def _lookup_hgvs_transcripts(annovar_variants: list):
     '''

--- a/cgd_tx_eff/test/edu/ohsu/compbio/txeff/test_tx_eff_hgvs.py
+++ b/cgd_tx_eff/test/edu/ohsu/compbio/txeff/test_tx_eff_hgvs.py
@@ -4,7 +4,7 @@ from edu.ohsu.compbio.txeff.variant_transcript import VariantTranscript
 
 class TxEffHgvsTest(unittest.TestCase):
         
-    def test_merge_annovar_with_hgvs(self):
+    def test__merge_annovar_with_hgvs(self):
         '''
         Merge two lists of transcripts and get only those that are common to both lists
         '''
@@ -20,7 +20,7 @@ class TxEffHgvsTest(unittest.TestCase):
         self.assertEqual(len(unmerged_transcripts), 2, 'Two transcripts are common to both lists')
         
     
-    def test_get_unmatched_annovar_transcripts(self):
+    def test__get_unmatched_annovar_transcripts(self):
         '''
         Given two dictionary objects, create a list of values based on the the symmetric difference of the keys  
         '''        
@@ -53,7 +53,7 @@ class TxEffHgvsTest(unittest.TestCase):
         self.assertTrue(t5.get_label() in labels, 't5 is unmatched')
         self.assertTrue(t6.get_label() in labels, 't6 is unmatched')
         
-    def test_get_the_best_transcripts(self):
+    def test__get_the_best_transcripts(self):
         '''
         Given three versions of a transcript return then one with the most values and the latest version
         '''
@@ -65,6 +65,34 @@ class TxEffHgvsTest(unittest.TestCase):
         
         self.assertEqual(len(best), 1, 'Only one transcript expected')
         self.assertEqual(best[0].get_label(), '1-1-A-T-NM_000.2', 'Most complete, lastest version')
+    
+    def test__correct_indel_coords(self):
+        '''
+        Given a genotype the _correct_indel_coords function returns the nomenclature describing the variant change (the g., minus the g. prefix) 
+        ''' 
+        # Substitution 
+        genotype = '1-123-G-A'
+        chromosome, position, ref, alt = genotype.split('-')
+        pos_part = tx_eff_hgvs._correct_indel_coords(position, ref, alt)
+        self.assertEqual(pos_part, '123G>A', "g. is incorrect")
+
+        # Insertion 
+        genotype = '1-123-G-AC'
+        chromosome, position, ref, alt = genotype.split('-')
+        pos_part = tx_eff_hgvs._correct_indel_coords(position, ref, alt)
+        self.assertEqual(pos_part, '123_124insC', "g. is incorrect")
+
+        # Deletion
+        genotype = '1-123-AC-G'
+        chromosome, position, ref, alt = genotype.split('-')
+        pos_part = tx_eff_hgvs._correct_indel_coords(position, ref, alt)
+        self.assertEqual(pos_part, '124del', "g. is incorrect")
+        
+        # Indel        
+        genotype = '5-112175461-CAGTTCACTTGA-CGTC'
+        chromosome, position, ref, alt = genotype.split('-')
+        pos_part = tx_eff_hgvs._correct_indel_coords(position, ref, alt)
+        self.assertEqual(pos_part, '112175461_112175472delinsCGTC', "g. is incorrect")
         
     def _create_variant(self, chromosome, pos, ref, alt, transcript, gene=None, c_dot=None, p_dot_one=None, p_dot_three=None, variant_effect=None, variant_type=None, protein_transcript=None):
         '''
@@ -81,4 +109,3 @@ class TxEffHgvsTest(unittest.TestCase):
         variant_transcript.protein_transcript = protein_transcript
         
         return variant_transcript
-        

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.7" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.8" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,10 +1,10 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.5" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.7" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>
 
   <requirements>
-    <requirement type="package" version="0.13.3">vcfpy</requirement>
+    <requirement type="package" version="0.13.6">vcfpy</requirement>
     <requirement type="package" version="1.5.2">hgvs</requirement>
     <requirement type="package" version="0.6.9">bcbio-gff</requirement>
   </requirements>

--- a/cgd_tx_eff/tfx_cgd_comparison.xml
+++ b/cgd_tx_eff/tfx_cgd_comparison.xml
@@ -1,10 +1,10 @@
-<tool id="tfx_cgd_comparison" name="Tfx Comparison with CGD" version="0.4.3" >
+<tool id="tfx_cgd_comparison" name="Tfx Comparison with CGD" version="0.4.4" >
   <description>
     Generate a CSV for comparison of transcripts and nomenclature in CGD with the values found in the VCF produced by tx_eff_control.py.
   </description>
   
   <requirements>
-    <requirement type="package" version="0.13.3">vcfpy</requirement>
+    <requirement type="package" version="0.13.6">vcfpy</requirement>
     <requirement type="package" version="1.5.2">hgvs</requirement>
     <requirement type="package" version="1.17">htslib</requirement>
   </requirements>


### PR DESCRIPTION
In the CGDTfx environment Julie pointed out that indels were showing up as deletions. John fixed the issue by correcting the function that constructs the "g." value used to query HGVS/UTA. 