### PR TITLE
BIO-630 - tfx splicing variants are not included in vcf

### DIFF
--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -13,6 +13,13 @@ import re
 import os
 from hgvs.location import BaseOffsetPosition
 
+def is_annovar_splicing_type(value: str):
+    '''
+    Return true if the string value matches one of variant types that Annovar uses for splicing variants.  
+    '''
+    return value in ['splicing', 'ncRNA_splicing']
+
+
 class AnnovarFileType(Enum):
     '''
     Annovar file types supported by this parser
@@ -241,8 +248,7 @@ class AnnovarParser(object):
             annovar_recs.append(avf)
 
         return annovar_recs
-        
-
+    
     def _parse_variant_function_row(self, annovar_row: list):
         '''
         Takes a single row from an Annovar variant_function file and returns one or more AnnovarVariantFunction objects.
@@ -259,7 +265,8 @@ class AnnovarParser(object):
         logging.debug(f"Parsing variant {chrom}-{pos}-{ref}-{alt}")
         
         # Handle special cases of splicing variants
-        if annovar_row[0] == 'splicing' or annovar_row[0] == 'ncRNA_splicing':            
+        
+        if is_annovar_splicing_type(annovar_row[0]):            
             variant_type = None
             variant_splicing = annovar_row[0]
         else:
@@ -351,7 +358,7 @@ class AnnovarParser(object):
         for matching_genotypes in annovar_dict.values():
             left_rec = matching_genotypes[0]
             
-            if left_rec.splicing == 'splicing':
+            if is_annovar_splicing_type(left_rec.splicing):
                 # Splicing variants don't get merged, and as far as I know Annovar will only have one splicing
                 # variant per genotype.                  
                 assert len(matching_genotypes) == 1, "A genotype can only have one splicing variant"

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/avinput2vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/avinput2vcf.py
@@ -1,7 +1,7 @@
 '''
-Created on Jun 21, 2022
+Create a VCF by reading the variants from an annovar input file (*.avinput ). 
+This script does not sort the vcf so you should followup by running ``gatk SortVcf --INPUT unsorted.vcf --OUTPUT sorted.vcf``
 
-Convert an Annovar *.avinput file to VCF
 @author: pleyte
 '''
 import argparse

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/csv2avinput.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/csv2avinput.py
@@ -50,10 +50,11 @@ def _main():
         keys = set()
         key_maker = lambda x: "-".join([x['chromosome'], str(x['position_start']), str(x['position_end']), x['reference_base'], x['variant_base']])
         
-        rowId = 1
+        rowId = 0
         for row in csv_reader:
             key = key_maker(row)
             if key in keys:
+                # The CSV has one line for each transcript so each variant will be listed multiple times. 
                 logging.debug(f"Skipping duplicate variant {key}")
                 duplicates = duplicates + 1
             else:

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -69,16 +69,16 @@ def _main():
 
     # Use tx_eff_hgvs to fix the nomenclature
     tx_eff_hgvs.identify_hgvs_datasources() 
-    merged_transcripts = tx_eff_hgvs.get_updated_hgvs_transcripts(annovar_records)
+    selected_transcripts = tx_eff_hgvs.get_updated_hgvs_transcripts(annovar_records)
 
     # Use tx_eff_ccds to add CCDS transcripts
     tx_eff_ccds = TxEffCcds(args.ccds_map.name)
-    tx_eff_ccds.add_ccds_transcripts(merged_transcripts)
+    tx_eff_ccds.add_ccds_transcripts(selected_transcripts)
      
     # Use tx_eff_vcf to write the transcript effects to a VCF
-    tx_eff_vcf.create_vcf_with_transcript_effects(args.in_vcf.name, args.out_vcf.name, merged_transcripts)
+    tx_eff_vcf.create_vcf_with_transcript_effects(args.in_vcf.name, args.out_vcf.name, selected_transcripts)
     
-    print(f"Wrote {len(merged_transcripts)} transcripts to {args.out_vcf.name}")
+    print(f"Wrote {len(selected_transcripts)} transcripts to {args.out_vcf.name}")
     
     end_time = time.time()
     total_time = end_time - start_time

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -11,7 +11,7 @@ from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.3.8'
+VERSION = '0.3.9'
 
 def _parse_args():
     '''
@@ -55,8 +55,11 @@ def _main():
     '''
     main function
     '''
-    logging.config.dictConfig(TfxLogConfig().log_config)
     print("tfx_cgd is starting...")
+    
+    logging.config.dictConfig(TfxLogConfig().log_config)        
+    print(f"Log level={logging.root.getEffectiveLevel()}, file={logging.root.handlers[0].baseFilename}")
+    
     start_time = time.time()
     
     args = _parse_args()

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -11,7 +11,7 @@ from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.3.9'
+VERSION = '0.4.1'
 
 def _parse_args():
     '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_hgvs.py
@@ -26,6 +26,7 @@ from hgvs.exceptions import HGVSInvalidVariantError, HGVSUsageError, HGVSDataNot
 from edu.ohsu.compbio.annovar.annovar_parser import AnnovarVariantFunction
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
+from edu.ohsu.compbio.annovar import annovar_parser
 
 VERSION = '0.3.9'
 ASSEMBLY_VERSION = "GRCh37"
@@ -390,7 +391,8 @@ def _merge_into(transcript_key: str, new_transcript: VariantTranscript, hgvs_tra
     # Variant Type 
     ## Variant type is only provided by Annovar, and the value will be empty in the case of splice variants. 
     assert hgvs_transcript.variant_type == None
-    if annovar_transcript.splicing != 'splicing':
+    
+    if not annovar_parser.is_annovar_splicing_type(annovar_transcript.splicing):
         assert _noneIfEmpty(annovar_transcript.variant_type) != None, f'Variant type must not be empty for non-splicing transcripts. See {transcript_key}'
 
     if _allow_merge(new_transcript.variant_type, annovar_transcript.variant_type, transcript_key, 'variant_type'):
@@ -441,7 +443,7 @@ def get_summary(annovar_transcripts: list, annovar_variants: set, hgvs_transcrip
     
     # Collect annovar records into a map keyed by genotype and transcript
     for annovar_rec in annovar_transcripts:
-        if annovar_rec.splicing == 'splicing' or annovar_rec.splicing == 'ncRNA_splicing':
+        if annovar_parser.is_annovar_splicing_type(annovar_rec.splicing):
             annovar_splice_variant_transcript_count += 1
         elif annovar_rec.splicing != None and annovar_rec.splicing != '':
             logging.warning(f"Invalid value in splicing column: {annovar_rec.splicing}")

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
@@ -7,7 +7,7 @@ joins the two so we can compare the nomenclature used in transcript effects with
 The output file is horribly un-normalised: 
 - Every line has one CGD variant and transcript. 
 - The variant will be repeated on as many lines as there are transcripts associated with that variant in CGD. 
-- The tfx INFO fields (from vcf) corresponding to the variant are also on the the line for each variant. 
+- The tfx INFO fields (from vcf) corresponding to the variant are also on the line for each variant. 
     - The tfx values are duplicated on each line 
 
 @author: pleyte

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
@@ -4,6 +4,12 @@ Created on Jul 1, 2022
 Takes as input a VCF that has been updated with transcript effects, and a variant export CSV, and 
 joins the two so we can compare the nomenclature used in transcript effects with what is currently in CGD. 
 
+The output file is horribly un-normalised: 
+- Every line has one CGD variant and transcript. 
+- The variant will be repeated on as many lines as there are transcripts associated with that variant in CGD. 
+- The tfx INFO fields (from vcf) corresponding to the variant are also on the the line for each variant. 
+    - The tfx values are duplicated on each line 
+
 @author: pleyte
 '''
 import argparse
@@ -67,7 +73,7 @@ def process(vcf_filename: str, csv_export_filename: str, csv_out_filename: str):
         csv_out_writer = csv.writer(csv_out_file)
         csv_out_writer.writerow(out_fields)
         
-        # Iterate over each entry in the export file 
+        # Iterate over each entry in the export file
         for export_row in export_reader:
             logging.debug(f"Looking for {export_row['chromosome']}-{export_row['position_start']}-{export_row['reference_base']}-{export_row['variant_base']}")
             

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
@@ -54,10 +54,8 @@ class HgvsLookup(object):
             print(f'Variant: {transcript.chromosome}-{transcript.position}-{transcript.reference}-{transcript.alt}')
             print(f'  Gene: {transcript.hgnc_gene}')
             print(f'  g.: {transcript.sequence_variant}')
-            print(f'  c.: {transcript.hgvs_c_dot}')
-            print(f'  p.: {transcript.hgvs_p_dot_three}')
-            print(f'  Transcript: {transcript.refseq_transcript}')
-            print(f'  Protein Transcript: {transcript.protein_transcript}')
+            print(f'  c.: {transcript.refseq_transcript}:{transcript.hgvs_c_dot}')
+            print(f'  p.: {transcript.protein_transcript}:{transcript.hgvs_p_dot_three}')
             print(f'  Splicing: {transcript.splicing if transcript.splicing else "No"}')
             print('--------')
         

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
@@ -1,0 +1,79 @@
+'''
+Use the HGVS python library to lookup a single variant. This script allows us to test and debug 
+HGVS processing of a variant without having to run a VCF through tx_eff_control.py.  
+
+Created on Mar. 21, 2023
+
+@author: pleyte
+'''
+import logging
+import os
+from argparse import ArgumentParser
+import hgvs.assemblymapper
+import hgvs.dataproviders.uta
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
+from edu.ohsu.compbio.txeff import tx_eff_hgvs
+from edu.ohsu.compbio.txeff.variant_transcript import VariantTranscript
+
+class HgvsLookup(object):
+    def __init__(self):
+        '''
+        Constructor
+        '''
+        self.logger = logging.getLogger(__name__)
+        
+        if os.environ.get('HGVS_SEQREPO_DIR') is None:
+            self.logger.warning("The HGVS_SEQREPO_DIR environment variable is not defined. The remote seqrepo database will be used.")
+        else:
+            logging.info(f"Using SeqRepo {os.environ.get('HGVS_SEQREPO_DIR')}")
+                
+        if os.environ.get('UTA_DB_URL') is None:
+            logging.warning("The UTA_DB_URL environment variable is not defined. The remote UTA database will be used.")
+        else:
+            logging.info(f"Using UTA Database at {os.environ.get('UTA_DB_URL')}")
+
+    def find_genotype(self, genotype: str):
+        '''
+        Search UTA for transcripts associated with the genotype (e.g. 7-12345-C-G)
+        '''
+        chromosome, position, ref, alt = genotype.split('-')
+        variant = VariantTranscript(chromosome, position, ref, alt)
+        
+        transcripts = tx_eff_hgvs._lookup_hgvs_transcripts([variant])
+        logging.info(f"Found {len(transcripts)} transcripts associated with {genotype}")
+        
+        self.print_result_transcripts(transcripts)
+
+    def find_gene(self, gene:str):
+        hdp = hgvs.dataproviders.uta.connect()
+        gene = hdp.get_gene_info(gene)
+        print(f'Gene: {gene}')
+            
+    def print_result_transcripts(self, transcripts: list):
+        for transcript in transcripts:
+            print(f'Variant: {transcript.chromosome}-{transcript.position}-{transcript.reference}-{transcript.alt}')
+            print(f'  Gene: {transcript.hgnc_gene}')
+            print(f'  g.: {transcript.sequence_variant}')
+            print(f'  c.: {transcript.hgvs_c_dot}')
+            print(f'  p.: {transcript.hgvs_p_dot_three}')
+            print(f'  Transcript: {transcript.refseq_transcript}')
+            print(f'  Protein Transcript: {transcript.protein_transcript}')
+            print(f'  Splicing: {transcript.splicing if transcript.splicing else "No"}')
+            print('--------')
+        
+if __name__ == '__main__':
+    logging.config.dictConfig(TfxLogConfig().utility_config)
+    parser = ArgumentParser(description='Use the HGVS python library to lookup a single variant')
+    parser.add_argument("-v", "--variant_genotype", help="Variant genotype (e.g. 7-123456-C-G)", type=str, required=False)
+    parser.add_argument("-g", "--gene", help="Gene name", type=str, required=False)
+
+    args = parser.parse_args()
+    
+    hgvs_lookup = HgvsLookup()
+    
+    if args.variant_genotype is not None:
+        hgvs_lookup.find_genotype(args.variant_genotype)
+    elif args.gene is not None:
+        hgvs_lookup.find_gene(args.gene)
+    else:
+        print("Please specify genotype or gene")

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/variant_transcript.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/variant_transcript.py
@@ -23,8 +23,8 @@ class VariantTranscript(AnnovarVariantFunction):
         '''
         String representation of the VariantTranscript object
         '''
-        return f'[AnnovarVariantFunction: genotype={self.chromosome}-{self.position}-{self.reference}-{self.alt}-transcript={self.refseq_transcript}-{self.protein_transcript}'
-    
+        return f'[AnnovarVariantFunction: genotype={self.chromosome}-{self.position}-{self.reference}-{self.alt}-transcript={self.refseq_transcript}-{self.protein_transcript}' + ('-splicing' if self.splicing else '') 
+
     def get_copy(self):
         '''
         Return a copy of this trancript 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/variant_transcript.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/variant_transcript.py
@@ -10,6 +10,9 @@ class VariantTranscript(AnnovarVariantFunction):
         super().__init__(chromosome, position, ref, alt)
             
         self.protein_transcript = None
+        
+        # An hgvs.sequencevariant.SequenceVariant with g. notation 
+        self.sequence_variant = None
 
     def __eq__(self, obj):
         if obj is None:

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.8" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.9" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.3.9" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.4.2" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>


### PR DESCRIPTION
Previous code changes resulted in splicing variants no longer being exported exported to the tfx VCF. 