### PR TITLE
BIO-636 - Combine Annovar's information about a splicing transcript into a single record

### DIFF
--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -12,7 +12,7 @@ from edu.ohsu.compbio.txeff.util.tx_eff_pysam import PysamTxEff
 from edu.ohsu.compbio.txeff import tx_eff_annovar, tx_eff_hgvs, tx_eff_vcf
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 
-VERSION = '0.5.5'
+VERSION = '0.5.6'
 
 def _parse_args():
     '''
@@ -62,7 +62,13 @@ def _main():
     print(f"tfx_cgd {VERSION} is starting...")
     
     logging.config.dictConfig(TfxLogConfig().log_config)
-    print(f"Log level={logging.root.getEffectiveLevel()}, file={logging.root.handlers[0].baseFilename}")
+    
+    if logging.root.handlers[0].stream: 
+        output = str(logging.root.handlers[0].stream.name)
+    else:
+        output = logging.root.handlers[0].baseFilename
+        
+    print(f"Log level={logging.root.getEffectiveLevel()}, output={output}")
 
     start_time = time.time()
     

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/tfx_log_config.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/tfx_log_config.py
@@ -73,5 +73,32 @@ class TfxLogConfig(object):
             } 
         }
         
-        
-        
+        # Configuration for when you want to see logging on stdout 
+        self.stdout_config = { 
+            'version': 1,
+            'disable_existing_loggers': False,
+            'formatters': {
+                'standard': { 
+                    'format': '%(levelname)s: %(name)s::%(module)s:%(lineno)s: %(message)s'
+                },
+            },
+            'handlers': {
+                'default': {                     
+                    'formatter': 'standard',
+                    'class': 'logging.StreamHandler',
+                    'stream': 'ext://sys.stdout'
+                },
+            },
+            'loggers': { 
+                '': {  # root logger
+                    'handlers': ['default'],
+                    'level': 'DEBUG',
+                    'propagate': False
+                },
+                'edu.ohsu.compbio.txeff': { 
+                    'level': 'DEBUG',
+                    'propagate': False,
+                    'handlers': ['default'],
+                },
+            }
+        }

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.5.5" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.5.6" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>


### PR DESCRIPTION
Transcripts were being defined twice when the variant is splicing: one splicing transcript; and one intron or exon transcript.

This branch merges the splicing information with the intron (or exon) so we only send one instance of each transcript to CGD.