### PR TITLE
CGD-2039 - Add support for start loss

### DIFF
--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -105,10 +105,10 @@ class AnnovarParser(object):
         raw_exon = transcript_parts[2]
 
         if raw_exon == 'wholegene':
-            logging.debug(f'This transcript\'s raw_exon value is \'wholegene\' and is of no use: {transcript_parts}')
+            logging.debug(f"This transcript's raw_exon value is 'wholegene' which means it is a Stop Loss: {transcript_parts}")
             amino_acid_position = None 
             hgvs_basep = None
-            exon = None
+            exon = raw_exon
             hgvs_c_dot = None
             hgvs_p = None
             hgvs_three = None
@@ -245,6 +245,14 @@ class AnnovarParser(object):
             avf.hgvs_p_dot_three,         \
             avf.refseq_transcript = self._unpack_evf_transcript_tuple(transcript_tuple)
 
+            # Annovar sets the exon to "wholegene" to indicate a start loss. The 
+            # annotation "startloss" isn't a term Annovar uses, it is our own custom 
+            # type and it replaces whater the current value is (eg 'frameshift deletion').  
+            if avf.exon == "wholegene":
+                logging.info(f"Start loss (aka wholegene) detected, substituting variant_effect overwriting '{avf.variant_effect}' with 'startloss': {avf}")
+                avf.exon = None                
+                avf.variant_effect = 'startloss'
+                
             logging.debug(f"Parsed exonic_variant_function with transcript: {avf}")
             annovar_recs.append(avf)
 

--- a/cgd_tx_eff/test/edu/ohsu/compbio/txeff/test_tx_eff_hgvs.py
+++ b/cgd_tx_eff/test/edu/ohsu/compbio/txeff/test_tx_eff_hgvs.py
@@ -67,7 +67,7 @@ class TxEffHgvsTest(unittest.TestCase):
                               self._create_variant('1', 1, 'A', 'T', 'NM_000.3', gene='AAA'),
                               self._create_variant('1', 1, 'A', 'T', 'NM_000.2', gene='AAA', p_dot_one='p.(L1P)', variant_effect='Y')]
 
-        best = tx_eff_hgvs._get_the_best_non_splicing_transcripts(merged_transcripts)
+        best = tx_eff_hgvs._get_the_best_transcripts(merged_transcripts)
         
         self.assertEqual(len(best), 1, 'Only one transcript expected')
         self.assertEqual(best[0].get_label(), '1-1-A-T-NM_000.2', 'Most complete, lastest version')
@@ -94,11 +94,17 @@ class TxEffHgvsTest(unittest.TestCase):
         pos_part = tx_eff_hgvs._correct_indel_coords(chromosome, int(position), ref, alt, self._pysam_file)
         self.assertEqual(pos_part, '124del', "g. is incorrect")
         
-        # Indel        
+        # Indel
         genotype = '5-112175461-CAGTTCACTTGA-CGTC'
         chromosome, position, ref, alt = genotype.split('-')
         pos_part = tx_eff_hgvs._correct_indel_coords(chromosome, int(position), ref, alt, self._pysam_file)
-        self.assertEqual(pos_part, '112175461_112175472delinsCGTC', "g. is incorrect")
+        self.assertEqual(pos_part, '112175462_112175472delinsGTC', "g. is incorrect")
+        
+        # Repeat
+        genotype = '1-153924029-AG-A'
+        chromosome, position, ref, alt = genotype.split('-')
+        pos_part = tx_eff_hgvs._correct_indel_coords(chromosome, int(position), ref, alt, self._pysam_file)
+        self.assertEqual(pos_part, '153924033del', "g. is incorrect")
         
     def _create_variant(self, chromosome, pos, ref, alt, transcript, gene=None, c_dot=None, p_dot_one=None, p_dot_three=None, variant_effect=None, variant_type=None, protein_transcript=None):
         '''


### PR DESCRIPTION
When annovar finds a start-loss it populates the exon number with the value "wholegene". When that happens I set our ``AnnovarVariantFunction.variant_effect`` field to "startloss".  So i've made it look like Annovar has a new variant effect (See CGD's [VcfParserHelper.TfxVariantEffect](https://source.ohsu.edu/kdls/cgd/blob/feature/unify-transcript-effects/src/main/java/edu/ohsu/cgd/parser/VcfParserHelper.java) for a list of all of Annovar varient effects). 

This change required some changes in CGD that are being [reviewed](https://source.ohsu.edu/kdls/cgd/pull/34) right now. 