### PR TITLE
BIO-716 - The  biocommons / hgvs lib returns incorrect one letter aa for start loss 

### DIFF
--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -39,7 +39,7 @@ class AnnovarVariantFunction(object):
         assert type(position) == int or position.isnumeric(), 'Position must be an integer' 
         assert alt.find(',') == -1, 'ALT may only have one value'
         
-        self.chromosome = chromosome
+        self.chromosome = str(chromosome)
         self.position = int(position)
         self.reference = ref
         self.alt = alt
@@ -105,7 +105,7 @@ class AnnovarParser(object):
         raw_exon = transcript_parts[2]
 
         if raw_exon == 'wholegene':
-            logging.debug(f"This transcript's raw_exon value is 'wholegene' which means it is a Stop Loss: {transcript_parts}")
+            logging.debug(f"This transcript's raw_exon value is 'wholegene' which means it is a Start loss: {transcript_parts}")
             amino_acid_position = None 
             hgvs_basep = None
             exon = raw_exon
@@ -273,7 +273,7 @@ class AnnovarParser(object):
 
             # Annovar sets the exon to "wholegene" to indicate a start loss. The 
             # annotation "startloss" isn't a term Annovar uses, it is our own custom 
-            # type and it replaces whater the current value is (eg 'frameshift deletion').  
+            # type and it replaces whatever the current value is (eg 'frameshift deletion').  
             if avf.exon == "wholegene":
                 logging.info(f"Start loss (aka wholegene) detected, substituting variant_effect overwriting '{avf.variant_effect}' with 'startloss': {avf}")
                 avf.exon = None                

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/compare_cgd_tfx.py
@@ -10,6 +10,9 @@ The output file is horribly un-normalised:
 - The tfx INFO fields (from vcf) corresponding to the variant are also on the line for each variant. 
     - The tfx values are duplicated on each line 
 
+2024.2.6: This script is only used to generate a file used in the CGDTfx environment for validation on the "Tfx Comparison" page. Once The cgd_tx_eff tool 
+          goes to production this script should be deleted.
+
 @author: pleyte
 '''
 import argparse

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
@@ -9,7 +9,6 @@ Created on Mar. 21, 2023
 import logging
 import os
 from argparse import ArgumentParser
-import hgvs.assemblymapper
 import hgvs.dataproviders.uta
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff import tx_eff_hgvs

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/print_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/print_tfx.py
@@ -1,6 +1,34 @@
 '''
 Created on Sep. 21, 2023
 
+Read the transcript effects from vcf and render them in a text table like this: 
+
+```
+Variant: 16-89985662-GGACTAT-G
+Tfx                      0                       1
+-----------------------  ----------------------  ----------------------
+TFX_BASE_POSITION        -5                      -5
+TFX_EXON
+TFX_GENE                 MC1R                    MC1R
+TFX_G_DOT                g.89985662_89985667del  g.89985662_89985667del
+TFX_HGVSC                c.-5_1del               c.-5_1del
+TFX_HGVSP                p.Met1?                 p.Met1?
+TFX_SPLICE
+TFX_AMINO_ACID_POSITION
+TFX_TRANSCRIPT           NM_002386.3             CCDS56011.1
+TFX_VARIANT_TYPE         exonic                  exonic
+TFX_PROTEIN_TRANSCRIPT   NP_002377.4             NP_002377.4
+TFX_VARIANT_EFFECT       startloss               startloss
+```
+
+This script is a little awkward to run because it takes as it's parameter the line from a vcf. The best way to execute it is: 
+```sh
+grep -v '#' tfx.vcf | while read -r line ; do
+  python $TFX_HOME/src/edu/ohsu/compbio/txeff/util/print_tfx.py --tfx "$line"
+done
+```
+
+
 @author: pleyte
 '''
 import re


### PR DESCRIPTION
A start loss has the protein variant genotype ``p.Met1?``
and the corresponding single letter representation should be ``p.M1?``
but the hgvs lib is hard-coded to return ``p.Met1?`` for both the one and three letter versions. 

This appears to be a bug in https://github.com/biocommons/hgvs/blob/main/src/hgvs/edit.py line 194




