### PR TITLE
BIO-724 - Provide 10 bases on either side of variant as reference context 

### DIFF
--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annotate.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annotate.py
@@ -37,9 +37,8 @@ class TxEffAnnotate(object):
         '''
         Add annotations to each variant transcript
         '''
+        self.logger.info("Applying Reference context annotations")
         for transcript in transcripts:
-            # Add the reference context annotation
-            self.logger.info("Applying Reference context annotations")
             transcript.reference_context = self._get_reference_context(transcript)
 
     def _get_reference_context(self, transcript: VariantTranscript):
@@ -53,5 +52,4 @@ class TxEffAnnotate(object):
             
         context_stop = transcript.position + self.REFERENCE_CONTEXT_LENGTH_PER_SIDE - 1
         
-        # jDebug: what happens if context_start is negative? 
         return self.sr[refseq_chromosome][context_start:context_stop]

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annotate.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annotate.py
@@ -46,10 +46,11 @@ class TxEffAnnotate(object):
         Look up the reference sequence that surrounds a variant. 
         '''
         refseq_chromosome = chromosome_map.get_refseq(transcript.chromosome)
-        context_start = transcript.position - self.REFERENCE_CONTEXT_LENGTH_PER_SIDE
+
+        context_start = transcript.position - self.REFERENCE_CONTEXT_LENGTH_PER_SIDE - 1
         if context_start < 0:
             context_start = 0
             
-        context_stop = transcript.position + self.REFERENCE_CONTEXT_LENGTH_PER_SIDE - 1
+        context_stop = transcript.position + len(transcript.reference) + self.REFERENCE_CONTEXT_LENGTH_PER_SIDE - 1
         
         return self.sr[refseq_chromosome][context_start:context_stop]

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annotate.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annotate.py
@@ -1,0 +1,57 @@
+'''
+Created on Aug. 12, 2024
+
+@author: pleyte
+'''
+
+import logging
+import os
+
+from biocommons.seqrepo import SeqRepo
+
+from edu.ohsu.compbio.txeff.util import chromosome_map
+from edu.ohsu.compbio.txeff.variant_transcript import VariantTranscript
+
+
+class TxEffAnnotate(object):
+    '''
+    Add variant annotations to each variant transcript.  
+    '''
+    def __init__(self):
+        '''
+        Constructor
+        '''
+        # Set up a logger for this class
+        self.logger = logging.getLogger(__name__)
+        
+        # Setup the SeqRepo utility that will be used for the Reference Context annotation
+        if os.environ.get('HGVS_SEQREPO_DIR') is None:
+            raise ValueError("The HGVS_SEQREPO_DIR environment variable is not defined")
+        else:
+            self.logger.info(f"Using SeqRepo {os.environ.get('HGVS_SEQREPO_DIR')}")
+            self.sr = SeqRepo(os.environ.get('HGVS_SEQREPO_DIR'))
+        
+        self.REFERENCE_CONTEXT_LENGTH_PER_SIDE = 10
+        
+    def annotate(self, transcripts: list):
+        '''
+        Add annotations to each variant transcript
+        '''
+        for transcript in transcripts:
+            # Add the reference context annotation
+            self.logger.info("Applying Reference context annotations")
+            transcript.reference_context = self._get_reference_context(transcript)
+
+    def _get_reference_context(self, transcript: VariantTranscript):
+        '''
+        Look up the reference sequence that surrounds a variant. 
+        '''
+        refseq_chromosome = chromosome_map.get_refseq(transcript.chromosome)
+        context_start = transcript.position - self.REFERENCE_CONTEXT_LENGTH_PER_SIDE
+        if context_start < 0:
+            context_start = 0
+            
+        context_stop = transcript.position + self.REFERENCE_CONTEXT_LENGTH_PER_SIDE - 1
+        
+        # jDebug: what happens if context_start is negative? 
+        return self.sr[refseq_chromosome][context_start:context_stop]

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_ccds.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_ccds.py
@@ -23,7 +23,7 @@ class CcdsMapFileType(Enum):
     
 class TxEffCcds(object):
     '''
-    classdocs
+    This class adds CCDS accessions to the transcript effects 
     '''
     def __init__(self, refseq_to_ccds_file):
         '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -16,8 +16,7 @@ from edu.ohsu.compbio.txeff.tx_eff_vcf import TxEffVcf
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_pysam import PysamTxEff
 
-
-VERSION = '0.6.9'
+VERSION = '0.7.0'
 
 def _parse_args():
     '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -17,7 +17,7 @@ from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_pysam import PysamTxEff
 
 
-VERSION = '0.6.8'
+VERSION = '0.6.9'
 
 def _parse_args():
     '''
@@ -104,7 +104,7 @@ def _main():
     tx_eff_annotate.annotate(merged_transcripts)
     
     # Use tx_eff_vcf to write the transcript effects to a VCF
-    TxEffVcf(args.in_vcf.name, args.out_vcf.name).create_vcf(merged_transcripts)
+    TxEffVcf(VERSION, args.in_vcf.name, args.out_vcf.name).create_vcf(merged_transcripts)
     
     print(f"Wrote {len(merged_transcripts)} transcripts to {args.out_vcf.name}")
 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -8,6 +8,7 @@ import argparse
 import logging.config
 import time
 
+from edu.ohsu.compbio.txeff.tx_eff_annotate import TxEffAnnotate
 from edu.ohsu.compbio.txeff.tx_eff_annovar import TxEffAnnovar
 from edu.ohsu.compbio.txeff.tx_eff_ccds import TxEffCcds
 from edu.ohsu.compbio.txeff.tx_eff_hgvs import TxEffHgvs
@@ -98,6 +99,10 @@ def _main():
     tx_eff_ccds = TxEffCcds(args.ccds_map.name)
     tx_eff_ccds.add_ccds_transcripts(merged_transcripts)
 
+    # Add additional annotations to each variant 
+    tx_eff_annotate = TxEffAnnotate()
+    tx_eff_annotate.annotate(merged_transcripts)
+    
     # Use tx_eff_vcf to write the transcript effects to a VCF
     TxEffVcf(args.in_vcf.name, args.out_vcf.name).create_vcf(merged_transcripts)
     

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
@@ -12,11 +12,10 @@ from enum import Enum
 import logging.config
 import sys
 
-import vcfpy
-
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 from edu.ohsu.compbio.txeff.variant import Variant
+import vcfpy
 
 
 class TranscriptEffect(Enum):
@@ -209,55 +208,55 @@ class TxEffVcf(object):
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_EXON.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'Exon number associated with given transcript.')]))
+                                                                ('Description', 'Exon number associated with given transcript (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_GENE.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'HGNC gene symbol.')]))
+                                                                ('Description', 'HGNC gene symbol (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_G_DOT.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'HGVS g-dot nomenclature.')]))    
+                                                                ('Description', 'HGVS g-dot nomenclature (parallel array of values).')]))    
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_HGVSC.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'HGVS cdot nomenclature.')]))
+                                                                ('Description', 'HGVS cdot nomenclature (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_HGVSP1.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'HGVS pdot nomenclature, single letter amino acids.')]))
+                                                                ('Description', 'HGVS pdot nomenclature, single letter amino acids (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_HGVSP3.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'HGVS pdot nomenclature, three letter amino acids.')]))
+                                                                ('Description', 'HGVS pdot nomenclature, three letter amino acids (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_SPLICE.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'Splice site annotation.')]))
+                                                                ('Description', 'Splice site annotation (single value).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_TRANSCRIPT.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'Transcript identifier.')]))
+                                                                ('Description', 'Transcript identifier (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_VARIANT_EFFECT.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'Variant effect annotation.')]))
+                                                                ('Description', 'Variant effect annotation (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_VARIANT_TYPE.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'Variant type or location annotation.')]))
+                                                                ('Description', 'Variant type or location annotation (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_PROTEIN_TRANSCRIPT.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'Protein transcript.')]))
+                                                                ('Description', 'Protein transcript (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_AMINO_ACID_POSITION.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'Amino acid start position.')]))
+                                                                ('Description', 'Amino acid start position (parallel array of values).')]))
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_REFERENCE_CONTEXT.value),
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
-                                                                ('Description', 'Reference context.')]))
+                                                                ('Description', 'Reference context (single value).')]))
         
     
     def create_vcf(self, transcripts: list):

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
@@ -36,6 +36,7 @@ class TranscriptEffect(Enum):
     TFX_PROTEIN_TRANSCRIPT = 'TFX_PROTEIN_TRANSCRIPT'
     TFX_EXON = 'TFX_EXON'
     TFX_AMINO_ACID_POSITION = 'TFX_AMINO_ACID_POSITION'
+    TFX_REFERENCE_CONTEXT = 'TFX_REFERENCE_CONTEXT' 
 
 class TxEffVcf(object):
     def __init__(self, in_vcf:str, out_vcf:str):
@@ -105,6 +106,7 @@ class TxEffVcf(object):
             tfx_variant_types = []
             tfx_protein_transcripts = []
             tfx_amino_acid_positions = []
+            tfx_reference_contexts = []
             
             for transcript in transcripts:
                 tfx_base_positions.append(transcript.hgvs_base_position)
@@ -120,6 +122,7 @@ class TxEffVcf(object):
                 tfx_variant_types.append(transcript.variant_type)
                 tfx_protein_transcripts.append(transcript.protein_transcript)
                 tfx_amino_acid_positions.append(transcript.hgvs_amino_acid_position)
+                tfx_reference_contexts.append(transcript.reference_context)
     
             vcf_record.INFO[TranscriptEffect.TFX_BASE_POSITION.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_base_positions])]
             vcf_record.INFO[TranscriptEffect.TFX_EXON.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_exons])]
@@ -133,6 +136,7 @@ class TxEffVcf(object):
             vcf_record.INFO[TranscriptEffect.TFX_TRANSCRIPT.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_refseq_transcripts])]        
             vcf_record.INFO[TranscriptEffect.TFX_VARIANT_TYPE.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_variant_types])]        
             vcf_record.INFO[TranscriptEffect.TFX_PROTEIN_TRANSCRIPT.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_protein_transcripts])]
+            vcf_record.INFO[TranscriptEffect.TFX_REFERENCE_CONTEXT.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_reference_contexts])]
             
             # Replace spaces with underscore because spaces are not allowed in the INFO field.
             vcf_record.INFO[TranscriptEffect.TFX_VARIANT_EFFECT.value] = [':'.join([self._replaceNoneWithEmpty(x).replace(' ', '_') for x in tfx_variant_effects])]
@@ -217,6 +221,11 @@ class TxEffVcf(object):
                                                                 ('Number', '.'),
                                                                 ('Type', 'String'),
                                                                 ('Description', 'Amino acid start position.')]))
+        header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_REFERENCE_CONTEXT.value),
+                                                                ('Number', '.'),
+                                                                ('Type', 'String'),
+                                                                ('Description', 'Reference context.')]))
+        
     
     def create_vcf(self, transcripts: list):
         '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
@@ -39,7 +39,8 @@ class TranscriptEffect(Enum):
     TFX_REFERENCE_CONTEXT = 'TFX_REFERENCE_CONTEXT' 
 
 class TxEffVcf(object):
-    def __init__(self, in_vcf:str, out_vcf:str):
+    def __init__(self, tfx_version: str, in_vcf:str, out_vcf:str):
+        self.version = tfx_version
         self.logger = logging.getLogger(__name__)
         self.in_vcf_filename = in_vcf
         self.out_vcf_filename = out_vcf
@@ -84,15 +85,20 @@ class TxEffVcf(object):
         Transform the transcript details into parallel arrays and add them to each VCF row.  
         '''
         vcf_records = []
-            
+
         for (variant, vcf_record) in vcf_variant_dict.items():
             transcripts = transcript_dict.get(variant)
-            
+
             if not transcripts:
                 self.logger.warning(f"No transcripts found for VCF variant {variant}")
                 vcf_records.append(vcf_record)
                 continue
-                
+            
+            # These values are the same for all transcripts so there is only one value. 
+            tfx_splice = self._get_any_splicing(transcripts)            
+            tfx_reference_context = self._get_and_confirm_single_value('reference_context', lambda x: x.reference_context, transcripts)
+
+            # These values are different for each transcript
             tfx_base_positions = []
             tfx_exons = []
             tfx_genes = []
@@ -100,13 +106,11 @@ class TxEffVcf(object):
             tfx_c_dots = []
             tfx_p1 = []
             tfx_p3 = []
-            tfx_splice = []
             tfx_refseq_transcripts = []
             tfx_variant_effects = []
             tfx_variant_types = []
             tfx_protein_transcripts = []
             tfx_amino_acid_positions = []
-            tfx_reference_contexts = []
             
             for transcript in transcripts:
                 tfx_base_positions.append(transcript.hgvs_base_position)
@@ -116,14 +120,14 @@ class TxEffVcf(object):
                 tfx_c_dots.append(transcript.hgvs_c_dot)
                 tfx_p1.append(transcript.hgvs_p_dot_one)
                 tfx_p3.append(transcript.hgvs_p_dot_three)
-                tfx_splice.append(transcript.splicing)
                 tfx_refseq_transcripts.append(transcript.refseq_transcript)
                 tfx_variant_effects.append(transcript.variant_effect)
                 tfx_variant_types.append(transcript.variant_type)
                 tfx_protein_transcripts.append(transcript.protein_transcript)
                 tfx_amino_acid_positions.append(transcript.hgvs_amino_acid_position)
-                tfx_reference_contexts.append(transcript.reference_context)
     
+            vcf_record.INFO[TranscriptEffect.TFX_SPLICE.value] = [tfx_splice]
+            vcf_record.INFO[TranscriptEffect.TFX_REFERENCE_CONTEXT.value] = [tfx_reference_context]
             vcf_record.INFO[TranscriptEffect.TFX_BASE_POSITION.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_base_positions])]
             vcf_record.INFO[TranscriptEffect.TFX_EXON.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_exons])]
             vcf_record.INFO[TranscriptEffect.TFX_GENE.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_genes])]
@@ -131,13 +135,11 @@ class TxEffVcf(object):
             vcf_record.INFO[TranscriptEffect.TFX_HGVSC.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_c_dots])]
             vcf_record.INFO[TranscriptEffect.TFX_HGVSP1.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_p1])]
             vcf_record.INFO[TranscriptEffect.TFX_HGVSP3.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_p3])]
-            vcf_record.INFO[TranscriptEffect.TFX_SPLICE.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_splice])]
             vcf_record.INFO[TranscriptEffect.TFX_AMINO_ACID_POSITION.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_amino_acid_positions])]
             vcf_record.INFO[TranscriptEffect.TFX_TRANSCRIPT.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_refseq_transcripts])]        
             vcf_record.INFO[TranscriptEffect.TFX_VARIANT_TYPE.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_variant_types])]        
             vcf_record.INFO[TranscriptEffect.TFX_PROTEIN_TRANSCRIPT.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_protein_transcripts])]
-            vcf_record.INFO[TranscriptEffect.TFX_REFERENCE_CONTEXT.value] = [':'.join([self._replaceNoneWithEmpty(x) for x in tfx_reference_contexts])]
-            
+
             # Replace spaces with underscore because spaces are not allowed in the INFO field.
             vcf_record.INFO[TranscriptEffect.TFX_VARIANT_EFFECT.value] = [':'.join([self._replaceNoneWithEmpty(x).replace(' ', '_') for x in tfx_variant_effects])]
             
@@ -145,6 +147,32 @@ class TxEffVcf(object):
         
         return vcf_records
 
+    def _get_and_confirm_single_value(self, field_name, getter, transcripts: list):
+        '''
+        Takes a list of trancripts and a getter function for one of the fields in the transcript. This function
+        confirms that all the transcripts have the same value for that field, and returns the value. 
+        '''
+        if not transcripts:
+            return None
+        
+        # Use getter to extract all values and add them to a set 
+        values = set(map(getter, transcripts))
+        
+        if len(values) != 1:
+            raise ValueError(f"All values in {field_name} array should be the same but {transcripts[0]} has multiple: {values}")
+        
+        return values.pop()
+    
+    def _get_any_splicing(self, trancripts:list):
+        '''
+        Return any non-empty splicing value from the transcript list. If a variant is splicing then all the transcripts
+        identified by Annovar will be splicing. But HGVS/UTA doesn't know about splicing so its trancripts won't have a splicing value.
+        This function checks to see if any of the transcripts are splicing and returns the splicing value if one of them is.    
+        '''
+        for x in trancripts:
+            if x.splicing:
+                return x.splicing
+            
     def _replaceNoneWithEmpty(self, x: str):
         '''
         Return the empty string if x is None, otherwise return x
@@ -167,7 +195,8 @@ class TxEffVcf(object):
         Add the new transcript effect fields to the VCF header 
         '''
         header.add_line(vcfpy.HeaderLine('tfx_commandline', ' '.join(sys.argv)))
-    
+        header.add_line(vcfpy.HeaderLine('TfxVersion', self.version))
+        
         header.add_info_line(vcfpy.OrderedDict([('ID', TranscriptEffect.TFX_BASE_POSITION.value),
                                                 ('Number', '.'),
                                                 ('Type', 'String'),

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
@@ -21,7 +21,11 @@ from edu.ohsu.compbio.txeff.variant import Variant
 
 class TranscriptEffect(Enum):
     '''
-    The transcript effects that are added to VCF file
+    The transcript effects INFO fields that are added to the VCF file.
+    
+    Most of these INFO fields are ':' delimited parallel arrays where each index in one field is associated
+    with the same index in another field.  The TFX_SPLICE and TFX_REFERENCE_CONTEXT fields apply to all 
+    transcripts so they only have a single value.  
     ''' 
     TFX_GENE = 'TFX_GENE'
     TFX_TRANSCRIPT = 'TFX_TRANSCRIPT'

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/chromosome_map.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/chromosome_map.py
@@ -1,0 +1,89 @@
+'''
+Created on Aug. 1, 2024
+
+Provide mapping from refseq accession to chromosome number. 
+@author: pleyte
+'''
+
+refseq_to_ncbi = {
+    'NC_012920.1': 'MT', 
+    'NC_000001.10': '1',
+    'NC_000002.11': '2',     
+    'NC_000003.11': '3',
+    'NC_000004.11': '4', 
+    'NC_000005.9': '5',
+    'NC_000006.11': '6', 
+    'NC_000007.13': '7',
+    'NC_000008.10': '8', 
+    'NC_000009.11': '9',
+    'NC_000010.10': '10', 
+    'NC_000011.9': '11',
+    'NC_000012.11': '12', 
+    'NC_000013.10': '13',
+    'NC_000014.8': '14', 
+    'NC_000015.9': '15',
+    'NC_000016.9': '16', 
+    'NC_000017.10': '17',
+    'NC_000018.9': '18', 
+    'NC_000019.9': '19',
+    'NC_000020.10': '20', 
+    'NC_000021.8': '21',
+    'NC_000022.10': '22', 
+    'NC_000023.10': 'X',
+    'NC_000024.9': 'Y'
+}
+
+ncbi_to_refseq = {
+    'MT': 'NC_012920.1', 
+    '1': 'NC_000001.10',
+    '2': 'NC_000002.11',     
+    '3': 'NC_000003.11',
+    '4': 'NC_000004.11', 
+    '5': 'NC_000005.9',
+    '6': 'NC_000006.11', 
+    '7': 'NC_000007.13',
+    '8': 'NC_000008.10', 
+    '9': 'NC_000009.11',
+    '10': 'NC_000010.10', 
+    '11': 'NC_000011.9',
+    '12': 'NC_000012.11', 
+    '13': 'NC_000013.10',
+    '14': 'NC_000014.8', 
+    '15': 'NC_000015.9',
+    '16': 'NC_000016.9', 
+    '17': 'NC_000017.10',
+    '18': 'NC_000018.9', 
+    '19': 'NC_000019.9',
+    '20': 'NC_000020.10', 
+    '21': 'NC_000021.8',
+    '22': 'NC_000022.10', 
+    'X': 'NC_000023.10',
+    'Y': 'NC_000024.9' 
+}
+
+def get_refseq(chromosome_in_ncbi_format: str) -> str:
+    '''
+    Return refseq chromosome that is mapped to the requested NCBI formatted chromosome. If the requested chromosome is not 
+    mapped to anything then an error is raised.  
+    ''' 
+    if chromosome_in_ncbi_format.startswith('chr'):
+        chromosome_in_ncbi_format = chromosome_in_ncbi_format.replace('chr', '', 1)
+    
+    refseq_chromosome = ncbi_to_refseq.get(chromosome_in_ncbi_format)
+    
+    if not refseq_chromosome:
+        raise ValueError('Unrecognized RefSeq chromosome' + chromosome_in_ncbi_format)
+    
+    return refseq_chromosome 
+
+def get_ncbi(chromosome_in_refseq_format: str, include_chr_prefix = False) -> str:
+    '''
+    Return NCBI chromosome that is mapped to the requested RefSeq formatted chromosome. If the requested chromosome is not 
+    mapped to anything then an error is raised. 
+    '''
+    ncbi_chromosome = refseq_to_ncbi.get(chromosome_in_refseq_format)
+    
+    if not ncbi_chromosome:
+        raise ValueError('Unrecognized NCBI chromosome ' + chromosome_in_refseq_format)
+    
+    return 'chr'+ncbi_chromosome if include_chr_prefix else ncbi_chromosome 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
@@ -17,7 +17,6 @@ from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_pysam import PysamTxEff
 from edu.ohsu.compbio.txeff.variant_transcript import VariantTranscript
 
-
 class HgvsLookup(object):
     def __init__(self):
         '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
@@ -23,7 +23,7 @@ class HgvsLookup(object):
         Constructor
         '''
         self.logger = logging.getLogger(__name__)
-        
+
         if os.environ.get('HGVS_SEQREPO_DIR') is None:
             self.logger.warning("The HGVS_SEQREPO_DIR environment variable is not defined. The remote seqrepo database will be used.")
         else:

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/print_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/print_tfx.py
@@ -69,7 +69,6 @@ class PrintTfx(object):
             if not field.startswith('TFX'):
                 continue
             
-            
             # Unlike the other tfx fields these may be empty or only have a single value.             
             if field == 'TFX_SPLICE':
                 value = self._get_single_value(info_value)
@@ -86,9 +85,9 @@ class PrintTfx(object):
             assert len(info_value) == 1, "The INFO value returned by vcfpy should only have a single value"
             
             # transcript effects values are separated by a ':'. 
-            tfx_field_values[field] = info_value[0].split(':')                    
+            tfx_field_values[field] = info_value[0].split(':')
             
-            # Make sure all the deliited tfx fields (except splice and ref context) have the same number of values
+            # Make sure all the delimited tfx fields (except splice and ref context) have the same number of values
             if not tfx_array_length:
                 tfx_array_length = len(tfx_field_values[field])
             elif tfx_array_length != len(tfx_field_values[field]):
@@ -111,11 +110,16 @@ class PrintTfx(object):
         Print a table of tfx values with labels (eg TFX_TRANSCRIPT) starting each row, and each column being 
         an index in the array of values. 
         '''
+        # Number of values in the list for every key is the same.  
         array_length = len(next(iter(records.values())))
+        
+        # Column headings
         headers = ['Tfx'] + list(range(0,array_length))
+        
         values_matrix = []
 
         for key, values in records.items():
+            # The first column is the label, the rest are the list of values 
             tfx_row = [key] + values
             values_matrix.append(tfx_row)
             

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/print_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/print_tfx.py
@@ -14,7 +14,6 @@ TFX_GENE                 MC1R                    MC1R
 TFX_G_DOT                g.89985662_89985667del  g.89985662_89985667del
 TFX_HGVSC                c.-5_1del               c.-5_1del
 TFX_HGVSP                p.Met1?                 p.Met1?
-TFX_SPLICE
 TFX_AMINO_ACID_POSITION
 TFX_TRANSCRIPT           NM_002386.3             CCDS56011.1
 TFX_VARIANT_TYPE         exonic                  exonic

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/print_tfx.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/print_tfx.py
@@ -25,8 +25,6 @@ TFX_VARIANT_EFFECT       startloss               startloss
 @author: pleyte
 '''
 from argparse import ArgumentParser
-import re
-
 from tabulate import tabulate
 import vcfpy
 
@@ -123,36 +121,6 @@ class PrintTfx(object):
             values_matrix.append(tfx_row)
             
         print(tabulate(values_matrix, headers=headers))
-        
-    def _parse(self, info:str) -> dict:
-        '''
-        Retrieve the TFX labels and value arrays from a vcf line and return them in a dict object
-        ''' 
-        
-        info_fields = info.split(';')
-        array_size = 0
-        type_values = dict()
-        
-        for info in info_fields:
-            if(info.startswith('TFX')):
-                label, values = self._parse_individual(info)
-                
-                if array_size == 0:
-                    array_size = len(values)
-                elif len(values) != array_size:
-                    raise ValueError(f"Inconsistent number of values found in {label} len={len(values)}, expected={array_size}")
-                    
-                type_values[label] = values
-        
-        return type_values
-                
-    def _parse_individual(self, section: str) -> (str, list):
-        '''
-        Return the TFX type and an array of values from a string like "TFX_BASE_POSITION=951:951:951:951"
-        '''
-        label = re.search('TFX_[A-Z_]+', section).group(0)
-        delimited_values = section.split("=",1)[1]
-        return label, delimited_values.split(':')
                 
 if __name__ == '__main__':
     parser = ArgumentParser(description='Read VCF with transcript effects and display the effects in a table.')

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/refseq_to_ccds.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/refseq_to_ccds.py
@@ -4,17 +4,18 @@ Created on Aug. 24, 2022
 @author: pleyte
 '''
 
-import csv
-import logging.config
-import sys
-
-from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, FileType
 from collections import defaultdict
-from BCBio import GFF
-
-import Bio
+import csv
+import logging.config
 from sys import getsizeof
+import sys
+
+from BCBio import GFF
+import Bio
+
+from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
+
 
 GFF_RELEASE_105 = '105'
 GFF_RELEASE_105_20220307 = '105.20220307'
@@ -93,7 +94,7 @@ class RefseqToCcds(object):
                 refseq_ids.update(sub_feature.qualifiers['transcript_id'])
             elif sub_feature.qualifiers['gbkey'][0] == 'CDS':
                 ccds_ids.add(self._get_ccds_id(sub_feature.qualifiers['Dbxref']))
-                    
+
         # It is possible for a feature to have a refseq id and not a ccds id.
         if len(refseq_ids) == 1 and len(ccds_ids) == 0:
             self.logger.debug(f"Refseq {refseq_ids.pop()} does not have a corresponding CCDS id")
@@ -141,6 +142,7 @@ class RefseqToCcds(object):
 
         assert len(dbxref_ccds_ids) == 1, f"Refseq {ref_seq_id} has more than one CCDS: {dbxref_ccds_ids}"
         ccds_id = dbxref_ccds_ids.pop()
+            
         return ref_seq_id, ccds_id
 
     def _get_ref_seq_id(self, s: str):        

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/variant_transcript.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/variant_transcript.py
@@ -13,6 +13,9 @@ class VariantTranscript(AnnovarVariantFunction):
         
         # An hgvs.sequencevariant.SequenceVariant with g. notation 
         self.sequence_variant = None
+        
+        # Reference sequence of 10 bases before and after the variant 
+        self.reference_context = None
 
     def __eq__(self, obj):
         if obj is None:
@@ -46,6 +49,8 @@ class VariantTranscript(AnnovarVariantFunction):
         transcript.splicing = self._noneIfEmpty(self.splicing)
         transcript.refseq_transcript = self._noneIfEmpty(self.refseq_transcript)
         transcript.protein_transcript = self._noneIfEmpty(self.protein_transcript)
+        transcript.reference_context = self._noneIfEmpty(self.reference_context)
+
         return transcript
 
     def _noneIfEmpty(self, value: str):

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.6.8" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.7.0" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>


### PR DESCRIPTION
Add a new type of transcript effect that is the variant context: the reference sequence from 10 bases before to 10 bases after the variant start position. 

The resulting INFO field looks like this:
```
;TFX_REFERENCE_CONTEXT=TGGCTGTAGGGGATGGATT:TGGCTGTAGGGGATGGATT:TGGCTGTAGGGGATGGATT;
```