### PR TITLE
Bio 728 transcript effects tool fails while parsing unrecognized transcript definition

### DIFF
--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -160,7 +160,7 @@ class AnnovarParser(object):
         
         exon = None
         hgvs_c_dot = None
-             
+
         # There are four different ways that information can be packaged that may in and annovar_row[. 
         # The format can be are determined by the number of ':' separated values. 
         tuple_type = len(delimited_transcript.split(':'))

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -160,9 +160,6 @@ class AnnovarParser(object):
         
         exon = None
         hgvs_c_dot = None
-
-        if 'NM_001306173.2(NM_001306173.2:exon12:c.1365+1G>T,NM_001306173.2:exon12:UTR3)' == delimited_transcript:
-            print("jDebug: found")
              
         # There are four different ways that information can be packaged that may in and annovar_row[. 
         # The format can be are determined by the number of ':' separated values. 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/annovar/annovar_parser.py
@@ -4,14 +4,16 @@ Created on Apr 14, 2022
 @author: pleyte
 '''
 
+from collections import defaultdict
 import csv
 from enum import Enum
-import hgvs.parser
 import logging
-from collections import defaultdict
-import re
 import os
+import re
+
 from hgvs.location import BaseOffsetPosition
+import hgvs.parser
+
 
 def is_annovar_splicing_type(value: str):
     '''
@@ -159,6 +161,9 @@ class AnnovarParser(object):
         exon = None
         hgvs_c_dot = None
 
+        if 'NM_001306173.2(NM_001306173.2:exon12:c.1365+1G>T,NM_001306173.2:exon12:UTR3)' == delimited_transcript:
+            print("jDebug: found")
+             
         # There are four different ways that information can be packaged that may in and annovar_row[. 
         # The format can be are determined by the number of ':' separated values. 
         tuple_type = len(delimited_transcript.split(':'))
@@ -177,7 +182,8 @@ class AnnovarParser(object):
             # looks like "NM_001077690.1(NM_001077690.1:exon1:c.60+1C>-,NM_001077690.1:exon2:c.61-1C>-)"
             refseq_transcript, exon, hgvs_c_dot = self._parse_transcript_tuple_type5(delimited_transcript)
         else:
-            raise ValueError("Tuple format not recognized: " + str(delimited_transcript))
+            self.logger.warning("Annovar tuple format not recognized: " + str(delimited_transcript))
+            refseq_transcript, exon, hgvs_c_dot = None, None, None
 
         # Strip the 'exon' prefix from 'exon5'
         if(exon):
@@ -225,9 +231,10 @@ class AnnovarParser(object):
         Example:
             - NM_001243965.1(NM_001243965.1:exon2:c.278+4C>A,NM_001243965.1:exon3:c.281+1C>A,NM_001243965.1:exon4:c.282-1C>A)
             - NM_001352417.1(NM_001352417.1:exon1:c.60+1C>-,NM_001352417.1:exon2:c.61-1C>-)
+            - NM_001306173.2(NM_001306173.2:exon12:c.1365+1G>T,NM_001306173.2:exon12:UTR3)
         This function returns a list of colon separated tuples like ['NM_x:exonN:c.','NM_y:exonM:c.'] 
         '''
-        p = re.compile('NM_[0-9]+\.[0-9]:exon[0-9]+:(?:r\.spl|c\.[-+0-9ACTG>]+)')
+        p = re.compile('NM_[0-9]+\.[0-9]:exon[0-9]+:(?:r\.spl|c\.[-+0-9ACTG>]+|UTR3|UTR5)')
         return p.findall(unparsed)
     
     def _parse_exonic_variant_function_row(self, annovar_row: list):
@@ -344,7 +351,11 @@ class AnnovarParser(object):
         '''
         Take an annovar variant_function field that has delimited information about transcripts 
         and split it into chunks for each transcript. The resulting string need to be further 
-        parsed by the _unpack_vf_transcript_tuple function
+        parsed by the _unpack_vf_transcript_tuple function.
+        Examples: 
+            NM_001005484.1(dist=28)
+            NM_001005484.1
+            NM_001005277.1(dist=168389),NR_125957.1(dist=25774) 
         '''
         p = re.compile('(?<=,)?([^\\(,]+(\\([^\\)]+\\))?)')
         matches = p.findall(unparsed)
@@ -365,7 +376,9 @@ class AnnovarParser(object):
         
         assert len(transcript_tuples) >= 2, "Unrecognised variant function delimited transcript definition"
         
+        # Even though there are multiple definitions of this transcript, we can only accept one. So we take the first.
         refseq_transcript, exon, hgvs_c_dot  = transcript_tuples[0].split(':')
+
         return refseq_transcript, exon, hgvs_c_dot
     
     def _parse_transcript_tuple_type3(self, unparsed):

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -79,18 +79,15 @@ def _main():
     args = _parse_args()
 
     # Use tx_eff_annovar to read annovar records
-    
     annovar_records = TxEffAnnovar().get_annovar_records(args.annovar_variant_function.name, args.annovar_exonic_variant_function.name)
 
     # Load the reference genome with pysam.
     pysam_file = PysamTxEff(args.reference_fasta)
 
-    tx_eff_hgvs = TxEffHgvs()
+    # Look for additional transcripts in the HGVA/UTA database and merge them with the annovar records.
+    with TxEffHgvs() as tx_eff_hgvs:
+        merged_transcripts = tx_eff_hgvs.get_updated_hgvs_transcripts(annovar_records, pysam_file)
     
-    # Use tx_eff_hgvs to fix the nomenclature
-    tx_eff_hgvs.identify_hgvs_datasources()
-
-    merged_transcripts = tx_eff_hgvs.get_updated_hgvs_transcripts(annovar_records, pysam_file)
     # Close the reference FASTA
     pysam_file.my_fasta.close()
 

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -16,7 +16,7 @@ from edu.ohsu.compbio.txeff.tx_eff_vcf import TxEffVcf
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_pysam import PysamTxEff
 
-VERSION = '0.7.1'
+VERSION = '0.7.2'
 
 def _parse_args():
     '''

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_vcf.py
@@ -12,10 +12,11 @@ from enum import Enum
 import logging.config
 import sys
 
+import vcfpy
+
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_csv import TxEffCsv
 from edu.ohsu.compbio.txeff.variant import Variant
-import vcfpy
 
 
 class TranscriptEffect(Enum):
@@ -79,8 +80,7 @@ class TxEffVcf(object):
         for transcript in transcripts:        
             variant = Variant(transcript.chromosome, transcript.position, transcript.reference, transcript.alt)
             transcript_dict[variant].append(transcript)
-            self.logger.debug(f"{variant} has {len(transcript_dict[variant])} transcripts")
-    
+
         return transcript_dict
 
     def _add_transcripts_to_vcf(self, vcf_variant_dict, transcript_dict):

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/hgvs_lookup.py
@@ -44,7 +44,8 @@ class HgvsLookup(object):
         # Reference file   
         pysam_file = PysamTxEff(reference_fasta)
         
-        transcripts = TxEffHgvs()._lookup_hgvs_transcripts([variant], pysam_file)
+        with TxEffHgvs() as tx_eff_hgvs:
+            transcripts = tx_eff_hgvs._lookup_hgvs_transcripts([variant], pysam_file)
 
         logging.info(f"Found {len(transcripts)} transcripts associated with {genotype}")
         
@@ -53,8 +54,9 @@ class HgvsLookup(object):
     def find_gene(self, gene:str):
         hdp = hgvs.dataproviders.uta.connect()
         gene = hdp.get_gene_info(gene)
+        hdp.close()
         print(f'Gene: {gene}')
-            
+
     def print_result_transcripts(self, transcripts: list):
         for transcript in transcripts:
             print(f'Variant: {transcript.chromosome}-{transcript.position}-{transcript.reference}-{transcript.alt}')

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.7.1" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.7.2" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>


### PR DESCRIPTION
I have re-opened this pull request because two more issues were found. 

Since you all have already reviewed the rest of the changes you can just review commit **20635ef**

The ``_get_gene_for_transcript`` was opening its own uta connection when one was already available. 
- rearranged the class so the uta connection, assembly mapper, and hgvs_parser are available throughout the lifespan of the class
- Added ``__enter__`` and ``__exit__`` function so TxEffHgvs can be used like this: `` with TxEffHgvs() as tx_eff_hgvs`` and it will be sure to close its connections. 

Also in ``_get_gene_for_transcript`` when you use ``hdp.get_tx_identity_info`` to lookup transcript information by accession, if the accession isn't found it throws an exception. And there are transcripts known to annovar that aren't known to uta. So i had to wrap the function call with try/except.