### PR TITLE
BIO-732 - Perform benchmarking of hgvs package used by transcript effects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 freak/data
 /.project
 /.pydevproject
+*.pyc

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annotate.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_annotate.py
@@ -7,7 +7,7 @@ Created on Aug. 12, 2024
 import logging
 import os
 
-from biocommons.seqrepo import SeqRepo
+from biocommons.seqrepo.seqrepo import SeqRepo
 
 from edu.ohsu.compbio.txeff.util import chromosome_map
 from edu.ohsu.compbio.txeff.variant_transcript import VariantTranscript

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -20,7 +20,8 @@ from edu.ohsu.compbio.txeff.tx_eff_vcf import TxEffVcf
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_pysam import PysamTxEff
 
-VERSION = '0.7.6d'
+
+VERSION = '0.7.6'
 
 def _parse_args():
     '''
@@ -117,7 +118,7 @@ def _main():
     tx_eff_ccds = TxEffCcds(args.ccds_map.name)
     tx_eff_ccds.add_ccds_transcripts(merged_transcripts)
 
-    # Add additional annotations to each variant 
+    # Add additional annotations to each variant
     tx_eff_annotate = TxEffAnnotate()
     tx_eff_annotate.annotate(merged_transcripts)
     

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -20,7 +20,7 @@ from edu.ohsu.compbio.txeff.tx_eff_vcf import TxEffVcf
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_pysam import PysamTxEff
 
-VERSION = '0.7.6a'
+VERSION = '0.7.6d'
 
 def _parse_args():
     '''
@@ -72,20 +72,17 @@ def _get_time(real_seconds, user_seconds):
     Take the real time and user time in seconds and return a string that breaks the time into hours, minutes, and seconds. 
     """
     
-    dt_real = datetime.time(second = round(real_seconds))
-    dt_user = datetime.time(second = round(user_seconds))
+    dt_real = datetime.timedelta(seconds = real_seconds)
+    dt_user = datetime.timedelta(seconds = user_seconds)
     
-    real = dt_real.strftime('%Hh:%Mm:%S.%fs')
-    user = dt_user.strftime('%Hh:%Mm:%S.%fs')
-    
-    return real, user
+    return str(dt_real), str(dt_user)
     
 def _main():
     '''
     main function
     '''
     print(f"tfx_cgd {VERSION} is starting...")
-    print("Python version: " + sys.version.replace('\\n', ''))
+    print("Python version: " + sys.version.replace('\n', ''))
     print(f"biocommons.seqrepo version: {biocommons.seqrepo.__version__}")
     print(f"hgvs version: {hgvs.__version__}")
     

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/tx_eff_control.py
@@ -3,10 +3,14 @@ Created on May 18, 2022
 
 @author: pleyte
 '''
-
 import argparse
+import datetime
 import logging.config
+import sys
 import time
+
+import biocommons.seqrepo
+import hgvs
 
 from edu.ohsu.compbio.txeff.tx_eff_annotate import TxEffAnnotate
 from edu.ohsu.compbio.txeff.tx_eff_annovar import TxEffAnnovar
@@ -16,7 +20,7 @@ from edu.ohsu.compbio.txeff.tx_eff_vcf import TxEffVcf
 from edu.ohsu.compbio.txeff.util.tfx_log_config import TfxLogConfig
 from edu.ohsu.compbio.txeff.util.tx_eff_pysam import PysamTxEff
 
-VERSION = '0.7.2'
+VERSION = '0.7.6a'
 
 def _parse_args():
     '''
@@ -52,18 +56,38 @@ def _parse_args():
                     help='Output VCF', 
                     type=argparse.FileType('w'), 
                     required=True)
-
+    
+    parser.add_argument('-b', '--benchmark',
+                    help='Write benchmarking information to file', 
+                    action='store_true')
+    
     parser.add_argument('--version', action='version', version='%(prog)s ' + VERSION)
     
     args = parser.parse_args()
     
     return args
 
+def _get_time(real_seconds, user_seconds):
+    """
+    Take the real time and user time in seconds and return a string that breaks the time into hours, minutes, and seconds. 
+    """
+    
+    dt_real = datetime.time(second = round(real_seconds))
+    dt_user = datetime.time(second = round(user_seconds))
+    
+    real = dt_real.strftime('%Hh:%Mm:%S.%fs')
+    user = dt_user.strftime('%Hh:%Mm:%S.%fs')
+    
+    return real, user
+    
 def _main():
     '''
     main function
     '''
     print(f"tfx_cgd {VERSION} is starting...")
+    print("Python version: " + sys.version.replace('\\n', ''))
+    print(f"biocommons.seqrepo version: {biocommons.seqrepo.__version__}")
+    print(f"hgvs version: {hgvs.__version__}")
     
     logging.config.dictConfig(TfxLogConfig().log_config)
     
@@ -74,8 +98,9 @@ def _main():
         
     print(f"Log level={logging.root.getEffectiveLevel()}, output={output}")
 
-    start_time = time.time()
-    
+    start_time_real = time.perf_counter()
+    start_time_user = time.process_time()
+
     args = _parse_args()
 
     # Use tx_eff_annovar to read annovar records
@@ -85,7 +110,7 @@ def _main():
     pysam_file = PysamTxEff(args.reference_fasta)
 
     # Look for additional transcripts in the HGVA/UTA database and merge them with the annovar records.
-    with TxEffHgvs() as tx_eff_hgvs:
+    with TxEffHgvs(benchmark = args.benchmark) as tx_eff_hgvs:
         merged_transcripts = tx_eff_hgvs.get_updated_hgvs_transcripts(annovar_records, pysam_file)
     
     # Close the reference FASTA
@@ -104,10 +129,12 @@ def _main():
     
     print(f"Wrote {len(merged_transcripts)} transcripts to {args.out_vcf.name}")
 
-    end_time = time.time()
-    total_time = end_time - start_time
-    time_str = time.strftime("%Mm:%Ss", time.gmtime(total_time))
-    print(f"Completed in {time_str}")
+    stop_time_real = time.perf_counter()
+    stop_time_user = time.process_time()
+    real_time, user_time = _get_time(stop_time_real - start_time_real, stop_time_user - start_time_user) 
+    
+    print(f"Time: real {real_time}, user {user_time}")
+    logging.info(f"Time: real {real_time}, user {user_time}")
 
 if __name__ == '__main__':
     _main()

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/benchmarking.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/benchmarking.py
@@ -1,0 +1,118 @@
+'''
+Keep track of how long functions take to complete. This is meant to track functions that are 
+called multiple times. It keeps track of how long each call takes. And supports tracking of
+multiple functions simultaneously. 
+
+See test_benchmarking.py for example usage. 
+
+Created on Sep. 25, 2024
+
+@author: pleyte
+'''
+import logging
+import statistics
+from time import perf_counter
+
+class Benchmark():
+    def __init__(self, name):
+        self.name = name
+        self.start = None
+        self.stop = None        
+        self.durations = []
+
+class Benchmarking(object):
+    '''
+    classdocs
+    '''
+    def __init__(self):
+        '''
+        Constructor
+        '''
+        self.logger = logging.getLogger(__name__)
+        self._benchmarks = dict()
+        self._last_name_updated = None
+    
+    def start(self, name):
+        """
+        Start timing an event
+        """
+        assert name, "name must be specified"
+        benchmark = self._benchmarks.get(name)
+
+        if not benchmark:
+            benchmark = Benchmark(name)
+            self._benchmarks[name] = benchmark 
+
+        if benchmark.start or benchmark.stop:
+            raise ValueError(f"The stopwatch for {name} needs to be stopped or cancelled before it can be started again.")
+
+        self._last_name_updated = name
+
+        benchmark.start = perf_counter()
+
+    def stop(self, name):
+        """
+        Stop the timer for an event
+        """
+        benchmark = self._benchmarks.get(name)
+        
+        if not benchmark or not benchmark.start:
+            raise ValueError(f"Unable to stop because the stopwatch for {name} not been started")
+        
+        benchmark.stop = perf_counter()
+        
+        duration = benchmark.stop - benchmark.start
+        
+        benchmark.durations.append(duration)
+        
+        benchmark.start = None
+        benchmark.stop = None
+        
+        self._last_name_updated = None
+        
+    def cancel(self, name):
+        """
+        End an event timer without recording the duration.
+        """
+        benchmark = self._benchmarks.get(name)
+        
+        if not benchmark or not benchmark.start:
+            raise ValueError(f"Unable to cancel because the stopwatch for {name} not been started") 
+       
+        benchmark.start = None
+        benchmark.stop = None
+    
+    def cancel_last(self):
+        """
+        Cancel the stopwatch for whatever event was most recently started. 
+        """
+        self.cancel(self._last_name_updated)
+
+    def clear(self):
+        """
+        Remove all events being timed 
+        """
+        self._benchmarks.clear()
+    
+    def get_time_total(self, name):
+        """
+        Return the sum of all event times in milliseconds 
+        """
+        benchmark = self._benchmarks.get(name) 
+        return sum(benchmark.durations) * 1000.0
+    
+    def get_time_average(self, name):
+        """
+        Return the average event time in milliseconds
+        """
+        benchmark = self._benchmarks.get(name)
+        if len(benchmark.durations) == 0:
+            return 0
+        
+        return statistics.mean(benchmark.durations) * 1000.0
+    
+    def get_names(self):
+        """
+        Return the names of the events being monitored
+        """        
+        return self._benchmarks.keys()

--- a/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/tfx_log_config.py
+++ b/cgd_tx_eff/src/edu/ohsu/compbio/txeff/util/tfx_log_config.py
@@ -18,7 +18,8 @@ class TfxLogConfig(object):
             'disable_existing_loggers': False,
             'formatters': {
                 'standard': { 
-                    'format': '%(levelname)s: %(name)s::%(module)s:%(lineno)s: %(message)s'
+                    'format': '%(asctime)s %(levelname)s: %(name)s::%(module)s:%(lineno)s: %(message)s',
+                    'datefmt': '%Y-%m-%d %H:%M:%S'
                 },
             },
             'handlers': {

--- a/cgd_tx_eff/test/edu/ohsu/compbio/txeff/util/test_benchmarking.py
+++ b/cgd_tx_eff/test/edu/ohsu/compbio/txeff/util/test_benchmarking.py
@@ -1,0 +1,57 @@
+'''
+Test the Benchmarking class
+
+Created on Sep. 25, 2024
+
+@author: pleyte
+'''
+import math
+import time
+import unittest
+
+from edu.ohsu.compbio.txeff.util.benchmarking import Benchmarking
+
+
+class TestBenchmarking(unittest.TestCase):
+    '''
+    Test the Benchmarking class
+    '''    
+    def test__example1(self):
+        benchmarking = Benchmarking()
+                
+        n = 10
+        
+        # Number of seconds that each process will sleep for
+        # A's timer runs while it sleeps and its timer continues to run while B sleeps.    
+        a_sleep = 1/4
+        b_sleep = 1/8
+        
+        for x in range(n):
+            benchmarking.start("A")
+            time.sleep(a_sleep)
+        
+            benchmarking.start("B")
+            time.sleep(b_sleep)
+            benchmarking.stop("B")
+            
+            benchmarking.stop("A")
+
+        # Calculate expected amount of time spent sleeping and convert to milliseconds
+        a_expected_total = ( (n * a_sleep) + (n * b_sleep) ) * 1000.0
+        a_expected_average = a_expected_total / n
+        a_actual_total = benchmarking.get_time_total('A')
+        a_actual_average = benchmarking.get_time_average('A')
+        
+        # Since time spent sleeping isn't exact, compare total milliseconds with a tolerance of +/- 100.0ms     
+        self.assertTrue(math.isclose(a_expected_total, a_actual_total, abs_tol=1e+2), f'Total times are not close: {a_expected_total} and {a_actual_total}')
+        
+        # Average is smaller so compare average milliseconds with a tolerance of +/- 10.0ms
+        self.assertTrue(math.isclose(a_expected_average, a_actual_average, abs_tol=1e+1), f'Total times are not close: {a_expected_average} and {a_actual_average}')
+        
+        b_expected_total = n * b_sleep * 1000.0
+        b_expected_average = b_expected_total / n 
+        b_actual_total = benchmarking.get_time_total('B')
+        b_actual_average = benchmarking.get_time_average('B')
+
+        self.assertTrue(math.isclose(b_expected_total, b_actual_total, abs_tol=1e+2), f'Total times are not close: {b_expected_total} and {b_actual_total}')        
+        self.assertTrue(math.isclose(b_expected_average, b_actual_average, abs_tol=1e+1), f'Total times are not close: {b_expected_average} and {b_actual_average}')

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -1,4 +1,4 @@
-<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.7.2" >
+<tool id="tfx_cgd" name="Transcript Effects for CGD" version="0.7.6" >
   <description>
   	Update a VCF with transcript-effects and nomenclature from Annovar and HGVS.
   </description>
@@ -24,6 +24,9 @@
             #else
                 --reference_fasta ${reference_source.reference_sequence}
             #end if
+        #end if
+        #if $benchmarking_selector == "yes"
+           --benchmark
         #end if
     	--out_vcf "${out_vcf}"
 
@@ -60,13 +63,18 @@
             <when value="history">
                 <param name="reference_sequence" type="data" format="fasta" label="Reference" help="Reference sequence file." />
             </when>
-    </conditional>
+    </conditional>  
+    <param name="benchmarking_selector" type="select" help="Choose yes to enable benchmarking" label="Enable benchmarking?">
+        <option value="yes">Yes</option>
+        <option value="no" selected="true">No</option>
+    </param>
   </inputs>
  
   <outputs>
     <data format="vcf" name="out_vcf" label="${tool.name} on ${on_string}: VCF" />
     <data format="tsv" name="invalid_variants" label="Variants with invalid input format" from_work_dir="annovar.invalid_input"/>
     <data format="txt" name="log_file" label="Log file" from_work_dir="cgd_tx_eff.log"/>
+    <data format="csv" name="benchmark_file" label="Benchmark file" from_work_dir="benchmark.csv"/>
   </outputs>
 
   <tests>
@@ -87,8 +95,7 @@
   </tests>
   
   <help><![CDATA[
-usage: tx_eff_control.py [-h] 
-						 [-r] 
+usage: tx_eff_control.py [-h]
 						 [--version]
 						 --in_vcf IN_VCF 
 						 --ccds_map CCDS_MAP 
@@ -96,6 +103,7 @@ usage: tx_eff_control.py [-h]
 						 --annovar_exonic_variant_function ANNOVAR_EXONIC_VARIANT_FUNCTION 
                          --reference_fasta REFERENCE_FASTA
 						 --out_vcf OUT_VCF
+                         [--benchmark]
 ]]>
   </help>
   <citations>

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -5,7 +5,7 @@
 
   <requirements>
     <requirement type="package" version="0.13.6">vcfpy</requirement>
-    <requirement type="package" version="1.5.2">hgvs</requirement>
+    <requirement type="package" version="1.5.4">hgvs</requirement>
   </requirements>
 
   <version_command><![CDATA[
@@ -79,9 +79,10 @@
  
   <outputs>
     <data format="vcf" name="out_vcf" label="${tool.name} on ${on_string}: VCF" />
-    <data format="tsv" name="invalid_variants" label="Variants with invalid input format" from_work_dir="annovar.invalid_input"/>
     <data format="txt" name="log_file" label="Log file" from_work_dir="cgd_tx_eff.log"/>
-    <data format="csv" name="benchmark_file" label="Benchmark file" from_work_dir="benchmark.csv"/>
+    <data format="csv" name="benchmark_file" label="Benchmark file" from_work_dir="benchmark.csv">
+        <filter>benchmarking_selector == 'yes'</filter>
+    </data>
   </outputs>
 
   <tests>

--- a/cgd_tx_eff/tfx_cgd.xml
+++ b/cgd_tx_eff/tfx_cgd.xml
@@ -33,12 +33,19 @@
   ]]></command>
   
  <environment_variables>
-
-    <!-- Our Galaxy environments have HGVS_SEQREPO_DIR and UTA_DB_URL set already. If they weren't, the 
-    	 local HGVS and UTA locations would need to be defined here.
-    	<environment_variable name="HGVS_SEQREPO_DIR"></environment_variable>
-    	<environment_variable name="UTA_DB_URL"></environment_variable>
-    -->
+    <!--
+    Use environment variables to tell Transcript Effects where to find the UTA database and the SeqRepo sequence repository.
+    
+    * UTA: The environment variable UTA_DB_URL is required and looks like postgresql://name:password@host:5432/uta/uta_20210129
+    * SeqRepo: There are three ways that HGVS can use lookup sequences using coordinates: 
+        - Option 0: Install SeqRepo on the same node where Tanscript Effects will be run, and define the path to SeqRepo in 
+                  the HGVS_SEQREPO_DIR environment variable. 
+        - Option 1: Install SeqRepo on a server and access it using the SeqRepo REST Service (https://github.com/biocommons/seqrepo-rest-service/)
+                  by defining the URL of the service in the HGVS_SEQREPO_URL (eg http://127.0.0.1:5000/seqrepo/)
+        - Option 2: If neither HGVS_SEQREPO_DIR or HGVS_SEQREPO_URL are defined then HGVS will lookup sequences using 
+                  NCBI's E-utilities API (https://www.ncbi.nlm.nih.gov/books/NBK25500/). You will need to place your NCBI API
+                  key in the NCBI_API_KEY environment variable.    
+     -->
     <environment_variable name="PYTHONPATH">$__tool_directory__/src</environment_variable>
   </environment_variables>
  
@@ -63,7 +70,7 @@
             <when value="history">
                 <param name="reference_sequence" type="data" format="fasta" label="Reference" help="Reference sequence file." />
             </when>
-    </conditional>  
+    </conditional>
     <param name="benchmarking_selector" type="select" help="Choose yes to enable benchmarking" label="Enable benchmarking?">
         <option value="yes">Yes</option>
         <option value="no" selected="true">No</option>


### PR DESCRIPTION
There are two changes in this branch: 

**BIO-732 Perform benchmarking of hgvs package used by transcript effects**
Adding transcript effects to a VCF is taking a lot longer than expected. To figure out what is taking so long I've added a utility that tracks how much time is spent by the HGVS package's functions that use the UTA postgres database, and the SeqRepo file-based data. 

**BIO-733 Ignore Annovar Transcripts that are both Exonic and Intronic**
It seems annovar has conflicting information about a transcript and is saying that it is both intronic and exonic. When that happened transcript effects threw an error. Now, instead of an error tfx logs a message and then casts out the transcript since we can't trust it. 

Updated the galaxy config:
* Use the latest version of HGVS module
* Include comments explaining the different ways to access SeqRepo
* Remove the annovar.invalid_input output type because that is something that would be produced by the annovar tool, not tfx. And i've never seen it happen. 